### PR TITLE
Close open dialog when escape is clicked

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -246,6 +246,7 @@
     "react-animated-cursor": "^2.4.0",
     "react-color": "^2.19.3",
     "react-dom": "^18.0.0",
+    "react-hotkeys-hook": "^3.4.7",
     "react-inverted-scrollview": "^1.0.7",
     "react-router-dom": "^6.3.0",
     "react-spaces": "^0.3.2",

--- a/app/src/renderer/system/dialog/DialogManager.tsx
+++ b/app/src/renderer/system/dialog/DialogManager.tsx
@@ -1,10 +1,13 @@
 import { FC, useRef } from 'react';
 import { observer } from 'mobx-react';
 import { motion } from 'framer-motion';
+import { useHotkeys } from 'react-hotkeys-hook';
 import { useServices } from 'renderer/logic/store';
 import AppWindow from '../desktop/components/Window';
 import { getCenteredXY } from 'os/services/shell/lib/window-manager';
 import { dialogRenderers } from 'renderer/system/dialog/dialogs';
+import { OnboardingStep } from 'os/services/onboarding/onboarding.model';
+import { ShellActions } from 'renderer/logic/actions/shell';
 
 type DialogManagerProps = {
   dialogId?: string;
@@ -18,6 +21,15 @@ export const DialogManager: FC<DialogManagerProps> = observer(
     const desktopRef = useRef<any>(null);
     let dialogWindow: React.ReactNode | undefined;
     const isOpen = dialogId !== undefined;
+
+    // clear dialog on escape pressed if closable
+    useHotkeys('esc', () => {
+      let notOnboardingDialog = !Object.values(OnboardingStep).includes(dialogId as any);
+      if (isOpen && notOnboardingDialog && dialogRenderers[dialogId].hasCloseButton) {
+        ShellActions.closeDialog();
+        ShellActions.setBlur(false);
+      }
+    }, { enableOnTags: ['INPUT', 'TEXTAREA', 'SELECT']});
 
     if (isOpen) {
       const dialogConfig = dialogRenderers[dialogId];

--- a/yarn.lock
+++ b/yarn.lock
@@ -6273,6 +6273,11 @@ hosted-git-info@^4.1.0:
   dependencies:
     lru-cache "^6.0.0"
 
+hotkeys-js@3.9.4:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.9.4.tgz#ce1aa4c3a132b6a63a9dd5644fc92b8a9b9cbfb9"
+  integrity sha512-2zuLt85Ta+gIyvs4N88pCYskNrxf1TFv3LR9t5mdAZIX8BcgQQ48F2opUptvHa6m8zsy5v/a0i9mWzTrlNWU0Q==
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
@@ -9493,6 +9498,13 @@ react-helmet@^6.1.0:
     prop-types "^15.7.2"
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
+
+react-hotkeys-hook@^3.4.7:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-3.4.7.tgz#e16a0a85f59feed9f48d12cfaf166d7df4c96b7a"
+  integrity sha512-+bbPmhPAl6ns9VkXkNNyxlmCAIyDAcWbB76O4I0ntr3uWCRuIQf/aRLartUahe9chVMPj+OEzzfk3CQSjclUEQ==
+  dependencies:
+    hotkeys-js "3.9.4"
 
 react-inverted-scrollview@^1.0.7:
   version "1.0.7"


### PR DESCRIPTION
closes #86

Adds a key listener to DialogManager which closes the open dialog when escape is pressed if possible (not onboarding, has close button). Pulls in one dependency for managing hotkeys.