### PR TITLE
Wallet Demo Fix

### DIFF
--- a/app/src/os/services/tray/wallet.service.ts
+++ b/app/src/os/services/tray/wallet.service.ts
@@ -213,7 +213,7 @@ export class WalletService extends BaseService {
       this.state!.ethereum.initial(wallets);
       this.state!.bitcoin.initial(wallets);
     });
-    WalletApi.subscribeToTransactions(
+    /*WalletApi.subscribeToTransactions(
       this.core.conduit!,
       (transaction: any) => {
         console.log('WE GOT IT BOIZZZZ');
@@ -226,7 +226,7 @@ export class WalletService extends BaseService {
 
     WalletApi.getHistory(this.core.conduit!).then((history: any) => {
       this.state!.ethereum.applyHistory(history);
-    });
+    }); */
 
     this.setNetworkProvider(
       'realm.tray.wallet.set-network-provider',

--- a/app/src/renderer/apps/Wallet/views/common/New/Backup.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/New/Backup.tsx
@@ -74,7 +74,7 @@ export const Backup: FC<BackupProps> = observer((props: BackupProps) => {
         </Flex>
       </Flex>
       <Flex mt={2} width="100%" justifyContent="center">
-        <Button onClick={() => props.setScreen(NewWalletScreen.CONFIRM)}>I wrote it down</Button>
+        <Button onClick={() => props.setScreen(NewWalletScreen.PASSCODE/*CONFIRM*/)}>I wrote it down</Button>
       </Flex>
     </Flex>
   );

--- a/app/src/renderer/apps/Wallet/views/common/New/index.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/New/index.tsx
@@ -23,12 +23,13 @@ export const EthNew: FC<any> = observer(() => {
   const [screen, setScreen] = useState<NewWalletScreen>(NewWalletScreen.CREATE);
   const [passcode, setPasscode] = useState('');
   // TODO move this to background thread
-  const seedPhrase = useMemo(
+  /*const seedPhrase = useMemo(
     () => ethers.Wallet.createRandom().mnemonic.phrase,
     []
-  );
+  );*/
   // const seedPhrase =
   //   'govern mountain flush ordinary field adult stereo quiz humor pigeon flush stuff';
+  const seedPhrase = "envelope robot unlock mercy lizard nothing frozen outside laundry woman dial expand"
 
   let setPasscodeWrapper = (passcode: string) => {
     // console.log('setting passcode!');


### PR DESCRIPTION
Steps to run wallet demo:
1. Start ~zod and ~bus: ~bus just needs the %wallet agent to generate an address.
2. Start ganache with seedphrase: `envelope robot unlock mercy lizard nothing frozen outside laundry woman dial expand`
3. Set ~bus xpub in dojo with command `:wallet &wallet-action [%set-xpub %ethereum 'xpub6BowUwvLi4C8r19kDV3dtiKGCDUW5i8U4XgNG3Cf49rRjaSW8FV9dNbPnJExJZaTd7K9np5D4DqZ2kTHb9Cxde6SwdLQh8BQQL8dv4mvVKE']`
4. log in with zod, click wallet, should be able to send transactions to bus and see the balance change.