### PR TITLE
rooms: room creator must be present in a room or it cannot exist

### DIFF
--- a/app/src/os/api/rooms.ts
+++ b/app/src/os/api/rooms.ts
@@ -102,7 +102,6 @@ export const RoomsApi = {
     roomId: string,
     access: string,
     title: string,
-    enter: boolean
   ) => {
     // TODO add to roomapp state after poke???
 
@@ -114,7 +113,6 @@ export const RoomsApi = {
           rid: roomId,
           access: access,
           title: title,
-          enter: enter,
         },
       },
       onSuccess: () => {

--- a/app/src/os/services/tray/rooms.service.ts
+++ b/app/src/os/services/tray/rooms.service.ts
@@ -52,14 +52,12 @@ export class RoomsService extends BaseService {
       roomId: string,
       access: string,
       title: string,
-      enter: boolean
     ) => {
       return ipcRenderer.invoke(
         'realm.tray.rooms.create-room',
         roomId,
         access,
         title,
-        enter
       );
     },
     setView: (view: string) => {
@@ -243,14 +241,12 @@ export class RoomsService extends BaseService {
     roomId: string,
     access: string,
     title: string,
-    enter: boolean
   ) {
     return RoomsApi.createRoom(
       this.core.conduit!,
       roomId,
       access,
       title,
-      enter
     );
   }
   async getProvider(_event: any) {

--- a/app/src/renderer/apps/Rooms/NewRoom.tsx
+++ b/app/src/renderer/apps/Rooms/NewRoom.tsx
@@ -90,7 +90,6 @@ export const NewRoom: FC<BaseRoomProps> = observer((props: BaseRoomProps) => {
       `${roomsApp.provider}/${name}/${new Date().getTime()}`,
       isPrivate ? 'private' : 'public',
       name,
-      true
     ).then(() => {
       setLoading(false);
     });

--- a/desks/realm/app/rooms.hoon
+++ b/desks/realm/app/rooms.hoon
@@ -117,7 +117,7 @@
       (bump-room-v room [%enter src.bowl])
     ::
     ++  create
-      |=  [=rid:store =access:store =title:store enter=?]
+      |=  [=rid:store =access:store =title:store]
       ::
       :: assert unique room id
       ?<  (~(has by rooms) rid)
@@ -135,40 +135,26 @@
           capacity.room  max-occupancy:lib
         ==
       ::
-      :: branch on ifenter. some logic is repeated but this is cleaner
-      ?:  enter
-        :: leave old room
-        =^  cards  state
-          :: call the exit action handler
-          exit
-        ::
-        :: enter new room
-        =.  present.room
-            (~(put in present.room) src.bowl)
-        ::
-        :: creator is always on the whitelist
-        =.  whitelist.room
-          (~(put in whitelist.room) src.bowl)
-        :: insert the room
-        =.  rooms
-          (insert room)
-        ::
-        :: send exit cards and new room bump
-        :_  state
-        %+  weld  cards
-        (bump-room-v room [%enter src.bowl])
+      :: leave old room
+      =^  cards  state
+        :: call the exit action handler
+        exit
       ::
-      :: not autoenter
+      :: enter new room
+      =.  present.room
+          (~(put in present.room) src.bowl)
       ::
+      :: creator is always on the whitelist
       =.  whitelist.room
         (~(put in whitelist.room) src.bowl)
+      :: insert the room
       =.  rooms
         (insert room)
       ::
-      :: the room is new and empty,
-      :: so no bump
-      `state
-    ::
+      :: send exit cards and new room bump
+      :_  state
+      %+  weld  cards
+      (bump-room-v room [%enter src.bowl])
     ::
     ++  exit
       ::
@@ -176,6 +162,8 @@
       ::
       :: this assumes that a given ship
       ::   is only in one room.
+      :: should be a safe assumption,
+      ::   but depends on how the rest of this agent is implemented
       =/  rud=(unit rid:store)
         =/  looms  ~(val by rooms)
         |-
@@ -194,6 +182,12 @@
       :: grabbed the dudes rid
       =/  =room:store
         (~(got by rooms) rid)
+      ::
+      ::
+      ?:  =(creator.room src.bowl)
+        :: if the creator leaves,
+        ::   the room is deleted
+        (delete rid)
       ::
       ::
       =.  present.room

--- a/desks/realm/lib/rooms.hoon
+++ b/desks/realm/lib/rooms.hoon
@@ -47,6 +47,7 @@
     |=  act=^action
     ^-  json
     :: not used
+    ::
     *json
   ++  update
     |=  upd=^update
@@ -206,7 +207,7 @@
       :~  [%rid so]
           [%access access]
           [%title so]
-          [%enter bo]
+          :: [%enter bo]
       ==
     ++  set-title
       %-  ot

--- a/desks/realm/sur/rooms.hoon
+++ b/desks/realm/sur/rooms.hoon
@@ -67,7 +67,7 @@
       ::
       [%enter =rid]
       [%exit ~]
-      [%create =rid =access =title enter=?]
+      [%create =rid =access =title]
       [%set-title =rid =title]
       [%set-access =rid =access]
       [%set-capacity =rid =capacity]


### PR DESCRIPTION
this was previously only enforced in realm desktop, but now its on the backend.

this change is important for the webrtc refactor, since it will require a SFU server for each room. So empty rooms will have some additional overhead.

there is not yet a mechanism for transferring ownership of the room, but this is relatively simple to add.