### PR TITLE
/spaces path %add when joining remote space

### DIFF
--- a/desks/realm/app/spaces.hoon
+++ b/desks/realm/app/spaces.hoon
@@ -426,7 +426,10 @@
       =.  spaces.state          (~(put by spaces.state) [path space])
       =.  membership.state      (~(put by membership.state) [path members])
       :_  state
-      [%give %fact [/updates ~] spaces-reaction+!>([%remote-space path space members])]~
+      :~
+        [%give %fact [/updates ~] spaces-reaction+!>([%remote-space path space members])]
+        [%give %fact [/spaces ~] spaces-reaction+!>([%add space members])]
+      ==
     ::
     --
   ++  helpers


### PR DESCRIPTION
Forgot to send an %add update when joining a remote group.