### PR TITLE
Polish chat log

### DIFF
--- a/app/src/renderer/apps/Messages/ChatView.tsx
+++ b/app/src/renderer/apps/Messages/ChatView.tsx
@@ -1,5 +1,4 @@
 import {
-  FC,
   useEffect,
   useState,
   useMemo,
@@ -56,7 +55,7 @@ interface IProps {
   setSelectedChat: (chat: any) => void;
 }
 
-export const ChatView: FC<IProps> = observer((props: IProps) => {
+export const ChatView = observer((props: IProps) => {
   const { selectedChat, height, theme } = props;
   const { iconColor, dockColor, textColor, windowColor, mode } = theme;
 


### PR DESCRIPTION
- [ ] Faded state doesn't re-render on success. 
- [ ] Initial message fetch may trigger "No messages" instead of showing the newly fetched messages.
- [ ] Upload status indicator (if an image upload is happening, we should put in a loader element in the chat log)
- [ ] Get query s3-store on dm tray app open, not chat log open. 
- [ ] Handle failed images with error image placeholder