### PR TITLE
Fix empty context menu when no space permissions

### DIFF
--- a/app/src/renderer/components/People/PersonRow.tsx
+++ b/app/src/renderer/components/People/PersonRow.tsx
@@ -48,7 +48,11 @@ export const PersonRow = ({
   }
 
   useEffect(() => {
-    if (contextMenuOptions && contextMenuOptions !== getOptions(id)) {
+    if (
+      contextMenuOptions &&
+      contextMenuOptions.length &&
+      contextMenuOptions !== getOptions(id)
+    ) {
       setOptions(id, contextMenuOptions);
     }
   }, [contextMenuOptions, getOptions, id, setOptions]);


### PR DESCRIPTION
When in a space where you have no permission to kick someone, the context list was empty. This makes it so that it returns the default list instead.