### PR TITLE
Don't install desks if used hosted signup

### DIFF
--- a/app/src/os/services/onboarding/onboarding.service.ts
+++ b/app/src/os/services/onboarding/onboarding.service.ts
@@ -610,6 +610,13 @@ export class OnboardingService extends BaseService {
       this.state.installRealm();
       return;
     }
+
+    if (this.state.checkoutComplete) {
+      // hosted ship, we shouldn't try to install
+      this.state.installRealm();
+      return;
+    }
+
     // INSTALL_MOON is a string of format <moon>:<desk>,<desk>,<desk>,...
     // example: INSTALL_MOON=~hostyv:realm,courier,wallet
     const parts: string[] = process.env.INSTALL_MOON.split(':');

--- a/app/src/renderer/system/onboarding/InstallAgent.dialog.tsx
+++ b/app/src/renderer/system/onboarding/InstallAgent.dialog.tsx
@@ -19,12 +19,17 @@ export const InstallAgent = observer(() => {
   const { onboarding } = useServices();
   const [loading, setLoading] = useState(false);
 
+  const completedCheckout = onboarding.checkoutComplete;
   const shipName = onboarding.ship!.patp;
   const shipNick = onboarding.ship!.nickname;
   const shipColor = onboarding.ship!.color!;
   const avatar = onboarding.ship!.avatar;
 
   const installRealm = () => {
+    if (completedCheckout) {
+      return;
+    }
+
     setLoading(true);
     OnboardingActions.installRealm().finally(() => setLoading(false));
   };
@@ -87,7 +92,7 @@ export const InstallAgent = observer(() => {
             rightContent={
               onboarding.installer.isLoading ? (
                 <Spinner size={0} />
-              ) : onboarding.installer.isLoaded ? (
+              ) : onboarding.installer.isLoaded || completedCheckout ? (
                 <Icons ml={2} size={1} name="CheckCircle" />
               ) : (
                 <Icons ml={2} size={1} name="DownloadCircle" />
@@ -108,7 +113,7 @@ export const InstallAgent = observer(() => {
           >
             {onboarding.installer.state === 'error'
               ? `${onboarding.installer.errorMessage}`
-              : !onboarding.installer.isLoaded
+              : !onboarding.installer.isLoaded && !completedCheckout
               ? 'This will just take a minute'
               : 'Congrats! You are ready to enter a new world.'}
           </Text>


### PR DESCRIPTION
If during onboarding a user goes with our hosted offering, we shouldn't try to install desks on the last step. This PR marks them as already installed on the frontend and adds a check just in case to the `installDesks` service method to block the installation if checkout was completed.

Tested with a hosted purchase to confirm it's working.