### PR TITLE
Enable Sentry in development

### DIFF
--- a/app/src/renderer/index.tsx
+++ b/app/src/renderer/index.tsx
@@ -6,13 +6,10 @@ import App from './App';
 
 const environment = process.env.NODE_ENV;
 const isProd = environment === 'production';
-const isDebug = process.env.DEBUG_PROD === 'true';
 
 const sentryDsn = process.env.SENTRY_DSN;
 if (sentryDsn) {
   Sentry.init({
-    enabled: isProd,
-    debug: isDebug,
     environment,
     dsn: process.env.SENTRY_DSN,
     integrations: [new BrowserTracing()],


### PR DESCRIPTION
Thought I did this, but this makes sure we log dev issues too.

Sent a test issue to illustrate that issues are filterable by environment:

<img width="721" alt="Screenshot 2022-12-15 at 10 27 11 PM" src="https://user-images.githubusercontent.com/29574724/207970694-c1c3630f-0be0-435f-99c6-34a05286d432.png">
