### PR TITLE
Fix: selection causing renderer to hang

### DIFF
--- a/app/src/renderer/components/ContextMenu/useContextMenu.tsx
+++ b/app/src/renderer/components/ContextMenu/useContextMenu.tsx
@@ -65,7 +65,8 @@ export const ContextMenuProvider = ({ children }: ContextMenuProviderProps) => {
 
   const isValidCopy = useMemo(
     () =>
-      selected?.text &&
+      selected &&
+      selected.text &&
       (selected.element === mouseRef?.target ||
         selected.element.contains(mouseRef?.target as Node)),
     [isInputOrTextArea, mouseRef?.target, selected?.text, selected?.element]

--- a/app/src/renderer/logic/lib/selection.tsx
+++ b/app/src/renderer/logic/lib/selection.tsx
@@ -25,18 +25,18 @@ export const SelectionProvider = ({ children }: SelectionProviderProps) => {
   const [selected, setSelected] = useState<SelectionContextValue['selected']>();
 
   useEffect(() => {
-    document.addEventListener('selectionchange', () => {
-      const selection = document.getSelection()?.toString().trim();
-      if (selection && selection !== '')
-        setSelected({
-          text: selection,
-          element: document.getSelection()?.anchorNode
-            ?.parentElement as HTMLElement,
-        });
-    });
+    const handleSelection = () => {
+      const selection = document.getSelection();
+      if (!selection) return;
+      const text = selection.toString().trim();
+      const element = selection.anchorNode?.parentElement;
+      if (element) setSelected({ text, element });
+    };
+
+    document.addEventListener('selectionchange', handleSelection);
 
     return () => {
-      document.removeEventListener('selectionchange', () => {});
+      document.removeEventListener('selectionchange', handleSelection);
     };
   });
 


### PR DESCRIPTION
Problem: We were unsafely casting `selection.anchorNode?.parentElement as HTMLElement` when it is sometimes undefined, which was causing us to try to do `.contains()` on a falsy object.

Solution: make sure the element is truthy before assigning it to the context.