### PR TITLE
Fix selectedSpace.type error

### DIFF
--- a/app/src/renderer/system/desktop/components/SystemBar/components/CommunityBar/SpaceSelector/SelectedSpace.tsx
+++ b/app/src/renderer/system/desktop/components/SystemBar/components/CommunityBar/SpaceSelector/SelectedSpace.tsx
@@ -11,7 +11,7 @@ type EmptyPictureProps = {
 const EmptyPicture = styled.div<EmptyPictureProps>`
   height: 32px;
   width: 32px;
-  background: ${({ color }) => color || '#000'};
+  background: ${({ color }) => color ?? '#000'};
   border-radius: 4px;
 `;
 


### PR DESCRIPTION
- Remove the non-null assertion.
- Add a null check.
- Also fix EmptyPicture's prop types