### PR TITLE
found a useMemo happening after a return null

### DIFF
--- a/app/src/renderer/system/desktop/components/SystemBar/components/CommunityBar/AppDock/index.tsx
+++ b/app/src/renderer/system/desktop/components/SystemBar/components/CommunityBar/AppDock/index.tsx
@@ -48,6 +48,15 @@ export const AppDock = observer(() => {
     debouncedSetLocalDockApps(dockApps);
   }, [dockApps.length]);
 
+  const activeAndUnpinned = useMemo(
+    () =>
+      desktop.openApps.filter(
+        (appWindow: any) =>
+          dock && dock.findIndex((pinned) => appWindow.id === pinned) === -1
+      ),
+    [desktop.openApps, dock]
+  );
+
   if (!spacePath) return null;
 
   const pinnedApps = (
@@ -199,15 +208,6 @@ export const AppDock = observer(() => {
         );
       })}
     </Reorder.Group>
-  );
-
-  const activeAndUnpinned = useMemo(
-    () =>
-      desktop.openApps.filter(
-        (appWindow: any) =>
-          dock && dock.findIndex((pinned) => appWindow.id === pinned) === -1
-      ),
-    [desktop.openApps, dock]
   );
 
   const activeAndUnpinnedApps = (


### PR DESCRIPTION
We need to make sure to catch these. There must be a linter rule we can add. Before merging this, lets locate that linter rule because this has happened before in other places.

https://github.com/facebook/react/issues/15792