### PR TITLE
adding skipFetchSetup to JsonRpcProvider constructor

### DIFF
--- a/app/src/os/services/tray/wallet/protocols/ethereum.ts
+++ b/app/src/os/services/tray/wallet/protocols/ethereum.ts
@@ -44,7 +44,10 @@ export class EthereumProtocol implements BaseBlockProtocol {
       this.nodeURL = this.baseURL + '/gorli';
     }
     let alchemySettings: AlchemySettings;
-    this.ethProvider = new ethers.providers.JsonRpcProvider(this.nodeURL);
+    this.ethProvider = new ethers.providers.JsonRpcProvider({
+      skipFetchSetup: true,
+      url: this.nodeURL,
+    });
     if (this.protocol === ProtocolType.ETH_MAIN) {
       alchemySettings = {
         url: this.nodeURL,


### PR DESCRIPTION
After some investigation, I found the source of the issue with the production build for wallet.

https://github.com/ethers-io/ethers.js/issues/3536#issuecomment-1323302238

It seems when ethers is in a webworker / non-browser process, you have to create JsonRpcProvider like below:

```js
new ethers.providers.JsonRpcProvider({
      skipFetchSetup: true,
      url: this.nodeURL,
    })
``` 

Still investigating and testing this...

I think this needs to go in the hosting-api JsonRpcProvider