### PR TITLE
Fix null snapshot on boot

### DIFF
--- a/app/src/renderer/system/desktop/components/Home/AppInstall/store.ts
+++ b/app/src/renderer/system/desktop/components/Home/AppInstall/store.ts
@@ -134,9 +134,9 @@ export const appInstallStore = AppInstallStore.create({
   selectedShip: '',
   selectedDesk: '',
   loadingState: '',
-  coords: (persistedState && persistedState.coords) || {
-    left: 0,
-    top: 0,
+  coords: {
+    left: persistedState?.coords?.left ?? 0,
+    top: persistedState?.coords?.top ?? 0,
   },
   dimensions: { height: 450, width: 550 },
 });


### PR DESCRIPTION
Realm crashed on boot on my second computer because it had a faulty snapshot.

This just makes the null check more exhaustive.

<img width="1045" alt="Screenshot 2023-01-31 at 1 57 41 PM" src="https://user-images.githubusercontent.com/29574724/215766109-3cb26332-6aa1-4810-9091-efb8702622c2.png">
