### PR TITLE
Realm chat

### DIFF
--- a/desks/realm-chat/lib/chat-db.hoon
+++ b/desks/realm-chat/lib/chat-db.hoon
@@ -319,7 +319,7 @@
     |-
     ?:  =(index len)
       result
-    =/  i  (snag 0 valid-rows)
+    =/  i  (snag index valid-rows)
     =/  pre  (~(get by result) path.i)
     =/  lis
     ?~  pre


### PR DESCRIPTION
one of the main idosyncrasies with this is the following comment which appears in two places in %chat-db

```
:: for now we are assuming that subscribed clients are intelligent
:: enough to realize that a %del-paths-row also means remove the
:: related messages and peers
```