### PR TITLE
Fix setWindowButtonVisibility undefined on Linux/Windows

### DIFF
--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -182,8 +182,12 @@ const createMouseOverlayWindow = () => {
     },
   });
   newMouseWindow.setIgnoreMouseEvents(true);
-  newMouseWindow.setWindowButtonVisibility(false);
   newMouseWindow.loadURL(resolveHtmlPath('mouse.html'));
+
+  // Hide the traffic lights on macOS.
+  if (process.platform === 'darwin') {
+    newMouseWindow.setWindowButtonVisibility(false);
+  }
 
   newMouseWindow.webContents.on('did-finish-load', () => {
     hideCursor(newMouseWindow.webContents);


### PR DESCRIPTION
The `setWindowButtonVisibility` method is only defined on macOS https://www.electronjs.org/docs/latest/api/browser-window#winsetwindowbuttonvisibilityvisible-macos, causing the mouse layer to crash on Linux/Windows.