### PR TITLE
add space name to JSON responses

### DIFF
--- a/desks/realm/app/spaces.hoon
+++ b/desks/realm/app/spaces.hoon
@@ -546,7 +546,6 @@
     ++  on-current
       |=  [path=space-path:store]
       ^-  (quip card _state)
-      :: TODO I don't know when/why this function is called yet. Revisit
       :_  state(current path)
       [%give %fact [/current ~] spaces-reaction+!>([%current path])]~
     ::

--- a/desks/realm/lib/spaces.hoon
+++ b/desks/realm/lib/spaces.hoon
@@ -86,6 +86,7 @@
       :-  %current
       %-  pairs
       :~  [%path s+(spat /(scot %p ship.path.rct)/(space-name:encode space.path.rct))]
+          [%space s+space.path.rct]
       ==
     
       ::   %members
@@ -325,7 +326,9 @@
     |=  current=space-path:store
     ^-  json
     %-  pairs
-    ['path' s+(spat /(scot %p ship.current)/(space-name space.current))]~
+    :~  ['path' s+(spat /(scot %p ship.current)/(space-name space.current))]
+        ['space' s+space.current]
+    ==
   ::
   ++  spc
     |=  =space


### PR DESCRIPTION
This just provides a bit more information back to JSON frontends on sub / scry to current space.

```ts
old - current: {path: '/~zod/0v74tbf'}
new - current: {space: 'our', path: '/~zod/0v74tbf'}
```