### PR TITLE
dialog close was using app window close

### DIFF
--- a/app/src/renderer/system/desktop/components/AppWindow/Titlebar/TitlebarByType.tsx
+++ b/app/src/renderer/system/desktop/components/AppWindow/Titlebar/TitlebarByType.tsx
@@ -130,7 +130,9 @@ export const TitlebarByType = ({
         ? dialogRenderer(shell.dialogProps.toJSON())
         : dialogRenderer;
     noTitlebar = dialogConfig.noTitlebar!;
-    const onCloseDialog = dialogConfig.hasCloseButton ? onClose : undefined;
+    const onCloseDialog = dialogConfig.hasCloseButton
+      ? dialogConfig.onClose
+      : undefined;
     const onOpenDialog = dialogConfig.onOpen;
     CustomTitlebar = DialogTitlebar as FC<DialogTitlebarProps>;
     showDevToolsToggle = false;


### PR DESCRIPTION
The close button was not working on some dialogs. 

Found the bug in `TitlebarByType.tsx`. 