### PR TITLE
Fix mouse state not always updating to `text`

### DIFF
--- a/app/src/renderer/system/mouse/getMouseState.ts
+++ b/app/src/renderer/system/mouse/getMouseState.ts
@@ -3,8 +3,8 @@ import { MouseState } from './AnimatedCursor';
 const isTextElement = (element: Element): boolean =>
   element instanceof HTMLTextAreaElement ||
   (element instanceof HTMLInputElement &&
-    element.type === 'text' &&
-    !element.readOnly);
+    element.type !== 'checkbox' &&
+    element.type !== 'radio');
 
 const isResizeHandler = (element: Element): boolean =>
   element.classList.contains('app-window-resize');


### PR DESCRIPTION
Not all input fields have an explicit `type="text"` attribute.

This makes sure we include those, while excluding radio buttons and selects.