### PR TITLE
Fix preconstruct error (type export)

### DIFF
--- a/lib/design-system/src/general/index.ts
+++ b/lib/design-system/src/general/index.ts
@@ -11,4 +11,5 @@ export { Favicon } from './Favicon/Favicon';
 export { SectionDivider } from './SectionDivider/SectionDivider';
 export { Spinner } from './Spinner/Spinner';
 export { ProgressBar } from './ProgressBar/ProgressBar';
-export { MenuItem, MenuItemProps } from './MenuItem/MenuItem';
+export { MenuItem } from './MenuItem/MenuItem';
+export type { MenuItemProps } from './MenuItem/MenuItem';


### PR DESCRIPTION
The issue:

>Error: 'MenuItemProps' is not exported by src/general/MenuItem/MenuItem.tsx, imported by src/general/index.ts
>
> – https://github.com/holium/realm/actions/runs/4281339565/jobs/7454246290


The fix:

> If you are building a TypeScript package, chances are you're re-exporting a type in a way that's not compatible with `@babel/preset-typescript`. See [Building TypeScript packages](/guides/building-typescript-packages) for more information. To fix it, you should use [type-only imports and exports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)