### PR TITLE
Rooms signal fix

### DIFF
--- a/desks/realm/app/rooms-v2.hoon
+++ b/desks/realm/app/rooms-v2.hoon
@@ -189,8 +189,8 @@
         [%pass / %agent [to %rooms-v2] %poke rooms-v2-signal+!>([%signal from to rid data])]~
       ::  Receiving a signal from another ship
       :_  state
-      ?:  ?:  =(~ rid)  %.n
-          =(current.session rid)
+      ?:  ?~  current.session  %.n
+          =(u.current.session rid)
         [%give %fact [/lib ~] rooms-v2-signal+!>([%signal from to rid data])]~
       [%pass / %agent [src.bol dap.bol] %poke rooms-v2-session-action+!>([%leave-room rid])]~
     ::


### PR DESCRIPTION
I added a check to make sure that the rid matches the current room when receiving a signal. If no match, we send a leave poke back to src. This completely solves the signaling spam issue. I left in the signal timer in case a ship is unreachable.