### PR TITLE
Remove AppWindow BG

### DIFF
--- a/app/src/renderer/system/desktop/components/AppWindow/View/AppView.tsx
+++ b/app/src/renderer/system/desktop/components/AppWindow/View/AppView.tsx
@@ -151,7 +151,6 @@ const AppViewPresenter = ({ isResizing, isDragging, appWindow }: Props) => {
             bottom: 0,
             right: 0,
             position: 'absolute',
-            background: theme.currentTheme.windowColor,
             overflow: 'hidden',
           }}
         />

--- a/app/src/renderer/system/desktop/components/AppWindow/View/DevView.tsx
+++ b/app/src/renderer/system/desktop/components/AppWindow/View/DevView.tsx
@@ -149,7 +149,6 @@ const DevViewPresenter = ({ appWindow, isResizing }: Props) => {
           webpreferences="sandbox=false"
           isLocked={isResizing || loading.isOn}
           style={{
-            background: lighten(0.04, currentTheme.windowColor),
             width: 'inherit',
             height: '100%',
             position: 'relative',


### PR DESCRIPTION
removes the default theme window color as the bg so we can have apps layer on the transparent window