### PR TITLE
Fix: Relic browser greys out on search

### DIFF
--- a/app/src/renderer/apps/Browser/helpers/createUrl.test.ts
+++ b/app/src/renderer/apps/Browser/helpers/createUrl.test.ts
@@ -2,12 +2,12 @@ import { createUrl } from './createUrl';
 
 describe('createUrl', () => {
   it('should return the same query if it is a valid URL', () => {
-    const url = 'https://www.neeva.com';
+    const url = 'https://www.duckduckgo.com';
 
     expect(createUrl(url)).toEqual(url);
   });
   it('should add secure protocol to valid URLs', () => {
-    const url = 'www.neeva.com';
+    const url = 'www.duckduckgo.com';
 
     expect(createUrl(url)).toEqual(`https://${url}`);
   });
@@ -21,9 +21,9 @@ describe('createUrl', () => {
 
     expect(createUrl(url)).toEqual(`http://${url}`);
   });
-  it('should return all other queries as a neeva search', () => {
+  it('should return all other queries as a duckduckgo search', () => {
     const query = 'blabla';
-    const url = `https://neeva.com/search?q=${query}`;
+    const url = `https://duckduckgo.com/?q=${query}`;
 
     expect(createUrl(query)).toEqual(url);
   });

--- a/app/src/renderer/apps/Browser/helpers/createUrl.ts
+++ b/app/src/renderer/apps/Browser/helpers/createUrl.ts
@@ -16,9 +16,9 @@ const isLocaHostOrIpAddress = (query: string) =>
   Boolean(query.match(/^(localhost)/gi)) ||
   Boolean(query.match(/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?::\d+)?$/gi));
 
-export const homePage = 'https://neeva.com';
+export const homePage = 'https://duckduckgo.com';
 
-const searchBase = `${homePage}/search?q=`;
+const searchBase = `${homePage}/?q=`;
 
 export const createUrl = (query: string) => {
   let potentialUrl = query;

--- a/app/src/renderer/apps/Browser/store.ts
+++ b/app/src/renderer/apps/Browser/store.ts
@@ -20,7 +20,7 @@ export const BrowserModel = types
   .model('BrowserModel', {
     currentTab: types.optional(TabModel, {
       id: 'tab-0',
-      url: 'https://neeva.com',
+      url: 'https://duckduckgo.com',
       isSafe: true,
       loader: { state: 'initial' },
     }),


### PR DESCRIPTION
When the app is built and signed, Neeva search crashes the webview.

Which is why I'm switching the default search engine from `Neeva` to `DuckDuckGo` here.

I've confirmed it works on Mac & Windows.

(Ideally, we'd figure out *why* Neeva crashes the webview, but this is the pragmatic solution since I've been investigating this issue for a while without much progress. It's not the .plist file since it happens cross-OSs.)

Let me know if you have a privacy search engine you like better. @drunkplato 