### PR TITLE
Resubscribe on channel when quit event received

### DIFF
--- a/lib/conduit/src/index.ts
+++ b/lib/conduit/src/index.ts
@@ -287,6 +287,7 @@ export class Conduit extends EventEmitter {
               const reconnectSub = this.watches.get(eventId);
               reconnectSub?.onQuit?.(parsedData);
               this.setAsIdleWatch(eventId);
+              this.resubscribe(eventId);
             }
             break;
           //


### PR DESCRIPTION
@e1block found that we should receive a quit event from a subscription when we encounter the sse bug.