### PR TITLE
when a user opens a chat, hit the scry for the timestamp of the last …

### DIFF
--- a/app/src/renderer/stores/chat.store.ts
+++ b/app/src/renderer/stores/chat.store.ts
@@ -162,14 +162,15 @@ export const ChatStore = types
       }
       self.subroute = subroute;
     }),
-    setChat(path: string) {
+    setChat: flow(function* (path: string) {
       self.selectedChat = tryReference(() =>
         self.inbox.find((chat) => chat.path === path)
       );
       if (self.subroute === 'inbox') {
         self.subroute = 'chat';
       }
-    },
+      yield ChatIPC.refreshMessagesOnPath(path, window.ship);
+    }),
     togglePinned: flow(function* (path: string, pinned: boolean) {
       try {
         if (pinned) {


### PR DESCRIPTION
…message they had that was not from themselves, in order to ensure we didn't miss any messages due to weird timing/poke delivery issues