### PR TITLE
Add timeout to onboarding network requests

### DIFF
--- a/shared/src/onboarding/services/http.ts
+++ b/shared/src/onboarding/services/http.ts
@@ -1,11 +1,31 @@
+function timeoutPromise<T>(promise: Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error('timeout'));
+    }, 15000);
+    promise.then(
+      (res) => {
+        clearTimeout(timeoutId);
+        resolve(res);
+      },
+      (err) => {
+        clearTimeout(timeoutId);
+        reject(err);
+      }
+    );
+  });
+}
+
 export function http<T>(
   input: RequestInfo | URL,
   init?: RequestInit
 ): Promise<T> {
-  return fetch(input, init).then((response) => {
-    if (!response.ok) {
-      throw new Error(response.statusText);
-    }
-    return response.json();
-  });
+  return timeoutPromise(
+    fetch(input, init).then((response) => {
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+      return response.json();
+    })
+  );
 }


### PR DESCRIPTION
We had a backend bug for /claim where it didn't respond. That is now fixed, but it also raised the issue that the client should have a timeout, so here I'm adding a 15 second timeout.