### PR TITLE
When joining a space, the stall data doesn't get refresh in UI until logout/login

### DIFF
--- a/app/src/renderer/stores/models/bazaar.model.ts
+++ b/app/src/renderer/stores/models/bazaar.model.ts
@@ -72,7 +72,7 @@ export const DevAppModel = types.model('DevApp', {
 });
 
 export const WebApp = types.model('WebApp', {
-  id: types.identifier,
+  id: types.string,
   title: types.string,
   href: types.string,
   favicon: types.maybeNull(types.string),
@@ -83,7 +83,7 @@ export const WebApp = types.model('WebApp', {
 
 export const UrbitApp = types
   .model('UrbitApp', {
-    id: types.identifier,
+    id: types.string,
     title: types.string,
     info: types.maybeNull(types.string),
     color: types.string,
@@ -124,7 +124,7 @@ export const UrbitApp = types
   }));
 
 const NativeApp = types.model('NativeApp', {
-  id: types.identifier,
+  id: types.string,
   title: types.string,
   info: types.string,
   color: types.string,

--- a/app/src/renderer/stores/models/spaces.model.ts
+++ b/app/src/renderer/stores/models/spaces.model.ts
@@ -459,7 +459,6 @@ export const SpacesStore = types
     _onJoinedBazaar: flow(function* (joinedPayload: any) {
       const space = self.spaces.get(joinedPayload.path);
       if (!space) return;
-      space._setStall(joinedPayload.stall);
       const refreshedSpace = yield SpacesIPC.getSpace(joinedPayload.path);
       self.spaces.set(space.path, spaceRowToModel(refreshedSpace));
     }),


### PR DESCRIPTION
removed unnecessary setting in _onJoinedBazaar and removed the identifer from the App models. This may have been the source of the original stall issues.

Ticket: RE-119

## Description

**Reviewer Checklist**

- [ ] Pipeline passes
- [ ] Docs have been added / updated
- [ ] Tests have been added / updated
- [ ] Has been refactored if necessary
