### PR TITLE
Temporarily fix 500

### DIFF
--- a/shared/src/onboarding/services/http.ts
+++ b/shared/src/onboarding/services/http.ts
@@ -22,9 +22,6 @@ export function http<T>(
 ): Promise<T> {
   return timeoutPromise(
     fetch(input, init).then((response) => {
-      if (!response.ok) {
-        throw new Error(response.statusText);
-      }
       return response.json();
     })
   );


### PR DESCRIPTION
The BE is returning 500 for get-planets-to-sell even though the request/response is valid.

This will temporarily unblock onboarding. Will revert this PR once the BE is patched.