### PR TITLE
fix RE-89: close modal when photo is set, dont show two photos at once

### DIFF
--- a/shared/src/onboarding/components/PassportCardAvatar.tsx
+++ b/shared/src/onboarding/components/PassportCardAvatar.tsx
@@ -178,9 +178,9 @@ export const PassportCardAvatar = ({
       if (generatedImages?.[index - 1]?.downloadLink) {
         fetch(generatedImages[index - 1].downloadLink, { headers });
       }
-
-      avatarModal.toggleOff();
     }
+
+    avatarModal.toggleOff();
   };
 
   const onClickSourceText = () => {


### PR DESCRIPTION
Ticket: RE-89

there was also a bug where if a user selected a suggested image, and then also uploaded their own, the component would try to display both
