### PR TITLE
Dedupe wallet types

### DIFF
--- a/app/src/os/services/ship/wallet/protocols/BaseBlockProtocol.ts
+++ b/app/src/os/services/ship/wallet/protocols/BaseBlockProtocol.ts
@@ -1,5 +1,4 @@
-import { Asset } from 'renderer/stores/models/wallet.model';
-
+import { Asset } from '../wallet.types';
 import { BaseProtocol } from './BaseProtocol';
 
 /**

--- a/app/src/os/services/ship/wallet/wallet.types.ts
+++ b/app/src/os/services/ship/wallet/wallet.types.ts
@@ -1,3 +1,14 @@
+export enum NetworkType {
+  ETHEREUM = 'ethereum',
+  BITCOIN = 'bitcoin',
+}
+
+export enum NetworkStoreType {
+  ETHEREUM = 'Ethereum',
+  BTC_MAIN = 'Bitcoin Mainnet',
+  BTC_TEST = 'Bitcoin Testnet',
+}
+
 export type Asset = {
   addr: string; // smart contract address for eth
   id?: string; // chainId for eth, id for uqbar

--- a/app/src/renderer/apps/Wallet/WalletApp.tsx
+++ b/app/src/renderer/apps/Wallet/WalletApp.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import { observer } from 'mobx-react';
 
-import { Flex } from '@holium/design-system';
+import { Flex } from '@holium/design-system/general';
 
+import { NetworkType } from 'os/services/ship/wallet/wallet.types';
 import {
   BitcoinWalletType,
   EthWalletType,
-  NetworkType,
   TransactionType,
   WalletView,
 } from 'renderer/stores/models/wallet.model';
@@ -123,7 +123,7 @@ const WalletAppPresenter = () => {
 
   return (
     <Flex
-      onClick={(evt: any) => evt.stopPropagation()}
+      onClick={(evt) => evt.stopPropagation()}
       position="relative"
       height={dimensions.height - 24}
       width="100%"
@@ -136,12 +136,8 @@ const WalletAppPresenter = () => {
         network={
           walletStore.navState.network === 'ethereum' ? 'ethereum' : 'bitcoin'
         }
-        onAddWallet={async () =>
-          await walletStore.navigate(WalletView.CREATE_WALLET)
-        }
-        onSetNetwork={async (network: any) =>
-          await walletStore.setNetwork(network)
-        }
+        onAddWallet={() => walletStore.navigate(WalletView.CREATE_WALLET)}
+        onSetNetwork={(network) => walletStore.setNetwork(network)}
         hide={hideHeader}
       />
       {pendingIsVisible &&

--- a/app/src/renderer/apps/Wallet/views/List.tsx
+++ b/app/src/renderer/apps/Wallet/views/List.tsx
@@ -5,8 +5,8 @@ import { Button, Flex, Text } from '@holium/design-system';
 import {
   NetworkStoreType,
   NetworkType,
-  WalletView,
-} from 'renderer/stores/models/wallet.model';
+} from 'os/services/ship/wallet/wallet.types';
+import { WalletView } from 'renderer/stores/models/wallet.model';
 import { useShipStore } from 'renderer/stores/ship.store';
 
 import { WalletCard } from './common/WalletCard';

--- a/app/src/renderer/apps/Wallet/views/common/CreateWallet.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/CreateWallet.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react';
 
 import { Button, Flex, Text, TextInput } from '@holium/design-system';
 
-import { NetworkType } from 'renderer/stores/models/wallet.model';
+import { NetworkType } from 'os/services/ship/wallet/wallet.types';
 import { useShipStore } from 'renderer/stores/ship.store';
 
 type Props = {

--- a/app/src/renderer/apps/Wallet/views/common/Detail/Detail.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/Detail/Detail.tsx
@@ -3,11 +3,11 @@ import { observer } from 'mobx-react';
 
 import { Box, Button, Flex, Text } from '@holium/design-system';
 
+import { NetworkType } from 'os/services/ship/wallet/wallet.types';
 import {
   BitcoinWalletType,
   ERC20Type,
   EthWalletType,
-  NetworkType,
   WalletView,
 } from 'renderer/stores/models/wallet.model';
 import { useShipStore } from 'renderer/stores/ship.store';

--- a/app/src/renderer/apps/Wallet/views/common/Detail/Hero.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/Detail/Hero.tsx
@@ -4,14 +4,22 @@ import { observer } from 'mobx-react';
 import { QRCodeSVG } from 'qrcode.react';
 import styled from 'styled-components';
 
-import { Box, CopyButton, Flex, Icon, Text } from '@holium/design-system';
+import {
+  Box,
+  CopyButton,
+  Flex,
+  Icon,
+  Text,
+} from '@holium/design-system/general';
 
+import {
+  NetworkType,
+  ProtocolType,
+} from 'os/services/ship/wallet/wallet.types';
 import {
   BitcoinWalletType,
   ERC20Type,
   EthWalletType,
-  NetworkType,
-  ProtocolType,
 } from 'renderer/stores/models/wallet.model';
 import { useShipStore } from 'renderer/stores/ship.store';
 

--- a/app/src/renderer/apps/Wallet/views/common/Header.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/Header.tsx
@@ -2,15 +2,14 @@ import { rgba } from 'polished';
 
 import { Button, Flex, Icon, Text } from '@holium/design-system';
 
+import { NetworkType } from 'os/services/ship/wallet/wallet.types';
 import { useShipStore } from 'renderer/stores/ship.store';
-
-type Network = 'ethereum' | 'bitcoin';
 
 type Props = {
   showBack: boolean;
   isOnboarding: boolean;
-  network: Network | string;
-  onSetNetwork: (network: Network) => void;
+  network: NetworkType | string;
+  onSetNetwork: (network: NetworkType) => void;
   onAddWallet: () => void;
   hide: boolean;
 };

--- a/app/src/renderer/apps/Wallet/views/common/Network.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/Network.tsx
@@ -1,8 +1,8 @@
 import { observer } from 'mobx-react';
 
-import { Box, Flex, Text } from '@holium/design-system';
+import { Box, Flex, Text } from '@holium/design-system/general';
 
-import { ProtocolType } from 'renderer/stores/models/wallet.model';
+import { ProtocolType } from 'os/services/ship/wallet/wallet.types';
 
 type Props = {
   network: ProtocolType;

--- a/app/src/renderer/apps/Wallet/views/common/Transaction/AmountInput.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/Transaction/AmountInput.tsx
@@ -3,7 +3,8 @@ import { observer } from 'mobx-react';
 
 import { Box, Flex, Icon, Text, TextInput } from '@holium/design-system';
 
-import { ERC20Type, ProtocolType } from 'renderer/stores/models/wallet.model';
+import { ProtocolType } from 'os/services/ship/wallet/wallet.types';
+import { ERC20Type } from 'renderer/stores/models/wallet.model';
 import { useShipStore } from 'renderer/stores/ship.store';
 
 import { ContainerFlex, FlexHider } from './styled';

--- a/app/src/renderer/apps/Wallet/views/common/Transaction/Pane.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/Transaction/Pane.tsx
@@ -3,12 +3,9 @@ import { observer } from 'mobx-react';
 
 import { Avatar, Box, Button, Flex, Icon, Text } from '@holium/design-system';
 
+import { ProtocolType } from 'os/services/ship/wallet/wallet.types';
 import { shortened } from 'renderer/apps/Wallet/lib/helpers';
-import {
-  ERC20Type,
-  ProtocolType,
-  WalletView,
-} from 'renderer/stores/models/wallet.model';
+import { ERC20Type, WalletView } from 'renderer/stores/models/wallet.model';
 import { useShipStore } from 'renderer/stores/ship.store';
 
 import { AmountInput } from './AmountInput';

--- a/app/src/renderer/apps/Wallet/views/common/Transaction/Pending.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/Transaction/Pending.tsx
@@ -2,8 +2,8 @@ import { FC } from 'react';
 
 import { Button, Card, Flex, Icon, Spinner, Text } from '@holium/design-system';
 
+import { ProtocolType } from 'os/services/ship/wallet/wallet.types';
 import {
-  ProtocolType,
   TransactionType,
   WalletView,
 } from 'renderer/stores/models/wallet.model';

--- a/app/src/renderer/apps/Wallet/views/common/Transaction/RecipientInput.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/Transaction/RecipientInput.tsx
@@ -13,13 +13,23 @@ import {
   TextInput,
 } from '@holium/design-system';
 
-import { RecipientPayload } from 'renderer/stores/models/wallet.model';
 import { useShipStore } from 'renderer/stores/ship.store';
 
 import { shortened } from '../../../lib/helpers';
 import { ContainerFlex } from './styled';
 
-const RecipientInputPresenter = (props: {
+type RecipientPayload = {
+  recipientMetadata?: {
+    color: string;
+    avatar?: string;
+    nickname?: string;
+  };
+  patp: string;
+  address?: string | null;
+  gasEstimate?: number;
+};
+
+type Props = {
   setValid: (
     valid: boolean,
     recipient: {
@@ -29,7 +39,9 @@ const RecipientInputPresenter = (props: {
       patpAddress?: string;
     }
   ) => void;
-}) => {
+};
+
+const RecipientInputPresenter = (props: Props) => {
   const { walletStore } = useShipStore();
 
   const [icon, setIcon] = useState('blank');

--- a/app/src/renderer/apps/Wallet/views/common/Transaction/Send.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/Transaction/Send.tsx
@@ -3,11 +3,11 @@ import { observer } from 'mobx-react';
 
 import { Box, Flex, Text } from '@holium/design-system';
 
+import { ProtocolType } from 'os/services/ship/wallet/wallet.types';
 import {
   BitcoinWalletType,
   ERC20Type,
   EthWalletType,
-  ProtocolType,
 } from 'renderer/stores/models/wallet.model';
 import { useShipStore } from 'renderer/stores/ship.store';
 
@@ -63,7 +63,6 @@ export const SendTransaction: FC<SendTransactionProps> = observer(
             position="absolute"
             px={2}
             bottom="-12px"
-            // height="25px"
             min-width="80px"
             justifyContent="center"
             alignItems="center"

--- a/app/src/renderer/apps/Wallet/views/common/TransactionDetail.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/TransactionDetail.tsx
@@ -13,10 +13,12 @@ import {
 } from '@holium/design-system';
 
 import {
-  BitcoinWalletType,
-  EthWalletType,
   NetworkType,
   ProtocolType,
+} from 'os/services/ship/wallet/wallet.types';
+import {
+  BitcoinWalletType,
+  EthWalletType,
   TransactionType,
   WalletStoreType,
 } from 'renderer/stores/models/wallet.model';

--- a/app/src/renderer/apps/Wallet/views/common/WalletCard.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/WalletCard.tsx
@@ -3,11 +3,13 @@ import { useMemo } from 'react';
 import { Flex, Text } from '@holium/design-system';
 
 import {
+  NetworkType,
+  ProtocolType,
+} from 'os/services/ship/wallet/wallet.types';
+import {
   BitcoinWalletType,
   ERC20Type,
   EthWalletType,
-  NetworkType,
-  ProtocolType,
 } from 'renderer/stores/models/wallet.model';
 import { useShipStore } from 'renderer/stores/ship.store';
 

--- a/app/src/renderer/apps/Wallet/views/common/WalletSettings.tsx
+++ b/app/src/renderer/apps/Wallet/views/common/WalletSettings.tsx
@@ -15,9 +15,9 @@ import {
 
 import {
   SharingMode,
-  UISettingsType,
   WalletCreationMode,
-} from 'renderer/stores/models/wallet.model';
+} from 'os/services/ship/wallet/wallet.types';
+import { UISettingsType } from 'renderer/stores/models/wallet.model';
 import { useShipStore } from 'renderer/stores/ship.store';
 
 import { DeletePasscode } from './DeletePasscode';

--- a/app/src/renderer/apps/store.ts
+++ b/app/src/renderer/apps/store.ts
@@ -3,15 +3,14 @@ import { Instance, onSnapshot, types } from 'mobx-state-tree';
 
 import { Dimensions } from '@holium/design-system';
 
-import { RealmIPC } from 'renderer/stores/ipc';
 import {
   NetworkStoreType,
   ProtocolType,
   SharingMode,
   WalletCreationMode,
-  WalletStore,
-  WalletView,
-} from 'renderer/stores/models/wallet.model';
+} from 'os/services/ship/wallet/wallet.types';
+import { RealmIPC } from 'renderer/stores/ipc';
+import { WalletStore, WalletView } from 'renderer/stores/models/wallet.model';
 
 import { calculateAnchorPointById } from '../lib/position';
 import { RoomsAppState } from './Rooms/rooms.model';

--- a/app/src/renderer/stores/models/wallet.model.ts
+++ b/app/src/renderer/stores/models/wallet.model.ts
@@ -8,23 +8,23 @@ import {
   types,
 } from 'mobx-state-tree';
 
+import {
+  Asset,
+  CoinAsset,
+  NetworkStoreType,
+  NetworkType,
+  NFTAsset,
+  ProtocolType,
+  SharingMode,
+  WalletCreationMode,
+} from 'os/services/ship/wallet/wallet.types';
+
 import { appState } from '../app.store';
 import { WalletIPC } from '../ipc';
 import { shipStore } from '../ship.store';
 
 // 10 minutes
 const AUTO_LOCK_INTERVAL = 1000 * 60 * 10;
-
-export interface RecipientPayload {
-  recipientMetadata?: {
-    color: string;
-    avatar?: string;
-    nickname?: string;
-  };
-  patp: string;
-  address?: string | null;
-  gasEstimate?: number;
-}
 
 export enum WalletView {
   LIST = 'list',
@@ -42,17 +42,6 @@ export enum WalletView {
 const gweiToEther = (gwei: number) => {
   return gwei / 1000000000000000000;
 };
-
-export enum WalletCreationMode {
-  DEFAULT = 'default',
-  ON_DEMAND = 'on-demand',
-}
-
-export enum SharingMode {
-  NOBODY = 'nobody',
-  FRIENDS = 'friends',
-  ANYBODY = 'anybody',
-}
 
 const Settings = types
   .model('Settings', {
@@ -89,56 +78,7 @@ export const WalletSettings = types.model('WalletSettings', {
   passcodeHash: types.string,
 });
 
-export enum NetworkType {
-  ETHEREUM = 'ethereum',
-  BITCOIN = 'bitcoin',
-}
-
-export enum ProtocolType {
-  ETH_MAIN = 'Ethereum Mainnet',
-  ETH_GORLI = 'Görli Testnet',
-  BTC_MAIN = 'Bitcoin Mainnet',
-  BTC_TEST = 'Bitcoin Testnet',
-  UQBAR = 'Uqbar Network',
-}
 const Protocols = types.enumeration(Object.values(ProtocolType));
-
-export type Asset = {
-  addr: string; // smart contract address for eth
-  id?: string; // chainId for eth, id for uqbar
-  type: 'coin' | 'token' | 'multisig' | string;
-  data: NFTAsset | CoinAsset | MultiAsset;
-};
-
-// ERC-20
-export type CoinAsset = {
-  logo: string | null; // url of token logo image
-  symbol: string; // USDC, DAI, BNB, etc
-  decimals: number; // 8 - used to convert to human readable number
-  balance: number; // current account balance
-  totalSupply: number; // total supply of the coin
-  allowances: { [addr: string]: number };
-};
-
-// ERC-721
-export type NFTAsset = {
-  name: string;
-  tokenId: string;
-  description: string;
-  image: string;
-  transferable?: boolean;
-  properties: { [key: string]: string | object };
-};
-
-// ERC-1155
-export type MultiAsset = {
-  name: string;
-  decimals: number; // 8 - used to convert to human readable number
-  description: string;
-  image: string;
-  balance: number; // current account balance
-  properties: { [key: string]: string | object };
-};
 
 export const Transaction = types.model('Transaction', {
   hash: types.identifier,
@@ -764,11 +704,6 @@ export const EthStore = types
   }));
 export type EthStoreType = Instance<typeof EthStore>;
 
-export enum NetworkStoreType {
-  ETHEREUM = 'Ethereum',
-  BTC_MAIN = 'Bitcoin Mainnet',
-  BTC_TEST = 'Bitcoin Testnet',
-}
 const NetworkStores = types.enumeration(Object.values(NetworkStoreType));
 
 export const WalletNavState = types

--- a/app/src/renderer/stores/ship.store.ts
+++ b/app/src/renderer/stores/ship.store.ts
@@ -2,6 +2,12 @@ import { createContext, useContext } from 'react';
 import { flow, Instance, onSnapshot, SnapshotIn, types } from 'mobx-state-tree';
 
 import { RealmSessionCredentials } from 'os/realm.types';
+import {
+  NetworkStoreType,
+  ProtocolType,
+  SharingMode,
+  WalletCreationMode,
+} from 'os/services/ship/wallet/wallet.types';
 
 import { ChatStore } from './chat.store';
 import { ShipIPC } from './ipc';
@@ -12,14 +18,7 @@ import { FeaturedStore } from './models/featured.model';
 import { FriendsStore } from './models/friends.model';
 import { NotifStore } from './models/notification.model';
 import { SpacesStore } from './models/spaces.model';
-import {
-  NetworkStoreType,
-  ProtocolType,
-  SharingMode,
-  WalletCreationMode,
-  WalletStore,
-  WalletView,
-} from './models/wallet.model';
+import { WalletStore, WalletView } from './models/wallet.model';
 import { RoomsStore } from './rooms.store';
 
 export const ShipStore = types


### PR DESCRIPTION
Ticket: RE-110

Logic:

- All wallet types, e.g. NetworkType, in `wallet.types.ts`
  - Except UI types, e.g. WalletView, which remain in `wallet.model.ts`
