### PR TITLE
Block dragging window off screen

### DIFF
--- a/app/src/renderer/App.styles.tsx
+++ b/app/src/renderer/App.styles.tsx
@@ -9,7 +9,6 @@ import { BackgroundImage } from './system/system.styles';
 
 type Props = {
   realmTheme: ThemeType;
-  blur: boolean;
 };
 
 export const GlobalStyle = createGlobalStyle<Props>`

--- a/app/src/renderer/App.tsx
+++ b/app/src/renderer/App.tsx
@@ -42,7 +42,7 @@ const AppPresenter = () => {
   return (
     <MotionConfig transition={{ duration: 1, reducedMotion: 'user' }}>
       <AppStateProvider value={appState}>
-        <GlobalStyle blur={true} realmTheme={theme} />
+        <GlobalStyle realmTheme={theme} />
         {!shellStore.isFullscreen && <Titlebar />}
         <RealmBackground blurred={shellStore.isBlurred} wallpaper={bgImage} />
         <SelectionProvider>
@@ -51,8 +51,6 @@ const AppPresenter = () => {
               {booted ? <AppContent /> : <AppLoading />}
               {contextMenuMemo}
               <div id="portal-root" />
-              <div id="menu-root" />
-              <div id="audio-root" />
             </ErrorBoundary>
           </ContextMenuProvider>
         </SelectionProvider>

--- a/app/src/renderer/system/desktop/components/AppWindow/AppWindow.tsx
+++ b/app/src/renderer/system/desktop/components/AppWindow/AppWindow.tsx
@@ -407,7 +407,7 @@ const AppWindowPresenter = ({ appWindow }: Props) => {
       dragElastic={0}
       dragMomentum={false}
       dragListener={false}
-      drag={dragging.isOn}
+      drag
       dragControls={dragControls}
       initial={{
         opacity: 0,

--- a/app/src/renderer/system/system.styles.tsx
+++ b/app/src/renderer/system/system.styles.tsx
@@ -38,7 +38,6 @@ export const ResumingOverlay = styled.div`
 export const BackgroundWrap = styled(motion.div)`
   user-select: none;
   position: fixed;
-  z-index: 0;
   right: -22px;
   left: -22px;
   z-index: 0;
@@ -49,7 +48,7 @@ export const BackgroundWrap = styled(motion.div)`
 `;
 
 export const BackgroundImage = styled(motion.img)`
-  ${(props: { blur?: boolean; src?: string }) =>
+  ${(props: { src?: string }) =>
     props.src &&
     css`
       user-select: none;


### PR DESCRIPTION
## Description

Noticed that the "drag window off screen" blocker wasn't working properly on initial drag.  Setting `drag` to `true` fixes this behavior
