### PR TITLE
Space invites API & landing page

### DIFF
--- a/holium-com/tsconfig.json
+++ b/holium-com/tsconfig.json
@@ -6,7 +6,7 @@
     "noEmit": true,
     "incremental": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "react-jsx"
   },
   "include": [
     "src"

--- a/hosting-holium-com/tsconfig.json
+++ b/hosting-holium-com/tsconfig.json
@@ -6,7 +6,7 @@
     "noEmit": true,
     "incremental": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "react-jsx"
   },
   "include": [
     "src",

--- a/join-holium-com/README.md
+++ b/join-holium-com/README.md
@@ -1,0 +1,3 @@
+# @holium/join-holium-com
+
+The API and landing page for space invites at https://join.holium.com/:spaceId.

--- a/join-holium-com/components/Invite.tsx
+++ b/join-holium-com/components/Invite.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export type InviteProps = {
+  id: string;
+  from: string;
+  space: {
+    name: string;
+  };
+};
+
+type Props = {
+  invite: InviteProps;
+};
+
+export const Invite = ({ invite }: Props) => (
+  <div>
+    <h2>Invite to{invite.space.name}</h2>
+    <small>ID: {invite.id}</small>
+    <small>From: {invite.from}</small>
+  </div>
+);

--- a/join-holium-com/next-env.d.ts
+++ b/join-holium-com/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/join-holium-com/package.json
+++ b/join-holium-com/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@holium/join-holium-com",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^13.4.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "styled-components": "^5.3.6"
+  },
+  "devDependencies": {
+    "@preconstruct/next": "^4.0.0",
+    "@types/node": "^18.15.3",
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "babel-plugin-styled-components": "^2.1.1"
+  }
+}

--- a/join-holium-com/pages/_app.css
+++ b/join-holium-com/pages/_app.css
@@ -1,0 +1,5 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}

--- a/join-holium-com/pages/_app.tsx
+++ b/join-holium-com/pages/_app.tsx
@@ -1,0 +1,9 @@
+import { AppProps } from 'next/app';
+
+import './_app.css';
+
+const App = ({ Component, pageProps }: AppProps) => {
+  return <Component {...pageProps} />;
+};
+
+export default App;

--- a/join-holium-com/pages/index.tsx
+++ b/join-holium-com/pages/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { GetStaticProps } from 'next';
+
+import { Invite, InviteProps } from '../components/Invite';
+
+export const getStaticProps: GetStaticProps = async () => {
+  const invites = [
+    {
+      id: '1',
+      from: '~lomder-librun',
+      space: {
+        name: 'Realm Forerunners',
+      },
+    },
+  ];
+  return {
+    props: { invites },
+    revalidate: 10,
+  };
+};
+
+type Props = {
+  invites: InviteProps[];
+};
+
+const Home = ({ invites }: Props) => {
+  return (
+    <div>
+      <h1>Invites</h1>
+      <main>
+        {invites.map((invite) => (
+          <div key={invite.id}>
+            <Invite invite={invite} />
+          </div>
+        ))}
+      </main>
+    </div>
+  );
+};
+
+export default Home;

--- a/join-holium-com/tsconfig.json
+++ b/join-holium-com/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "shared",
     "holium-com",
     "hosting-holium-com",
+    "join-holium-com",
     "lib/design-system",
     "lib/presence",
     "lib/presence/code",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -47,6 +47,9 @@
       "path": "./hosting-holium-com"
     },
     {
+      "path": "./join-holium-com"
+    },
+    {
       "path": "./lib/design-system"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "shared",
     "holium-com",
     "hosting-holium-com",
+    "join-holium-com",
     "lib/design-system",
     "lib/presence/code",
     "lib/presence",


### PR DESCRIPTION
Ticket: RE-147

## Description

The Space Invite DB will need to store the following information:

```ts
type SpaceInvite = {
  id: string;   // -> join.holium.com/:id
  from: string; // ~lomder-librun
  space: {
    title: string;
    description: string;
    memberCount: number;
    theme: string;
  };
};
```

The Space Invite API should have CRUD operations for toggling a space invite link, as well as updating the space metadata such as theme and memberCount.

**Reviewer Checklist**

- [ ] Pipeline passes
- [ ] Docs have been added / updated
- [ ] Tests have been added / updated
- [ ] Has been refactored if necessary
