### PR TITLE
add tsc to lint option

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lib/room/test-ui"
   ],
   "scripts": {
-    "tsc": "yarn workspace @holium/realm tsc && yarn workspace @holium/design-system tsc && yarn workspace @holium/realm-presence tsc && yarn workspace @holium/realm-presence-notes tsc && yarn workspace @holium/shared tsc && yarn workspace @holium/holium-com tsc && yarn workspace @holium/hosting-holium-com tsc",
+    "tsc": "yarn workspace @holium/realm tsc --noemit && yarn workspace @holium/design-system tsc --noemit && yarn workspace @holium/realm-presence tsc --noemit && yarn workspace @holium/realm-presence-notes tsc --noemit && yarn workspace @holium/shared tsc --noemit && yarn workspace @holium/holium-com tsc --noemit && yarn workspace @holium/hosting-holium-com tsc --noemit",
     "postinstall": "yarn workspace @holium/realm postinstall",
     "build": "yarn build:app",
     "build:app": "yarn workspace @holium/realm build",
@@ -23,8 +23,8 @@
     "precommit": "yarn lint-staged",
     "lint": "eslint --fix -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRTUXB master | grep  -E \"(.js$|.jsx$|.ts$|.tsx$)\") --ignore-path .gitignore",
     "lint:ci": "eslint -c .eslintrc.js $(git diff --name-only --diff-filter=ACMRTUXB origin/master | grep  -E \"(.js$|.jsx$|.ts$|.tsx$)\") --ignore-path .gitignore",
-    "lint:all": "eslint --fix . --ext .js,.jsx,.ts,.tsx --ignore-path .gitignore",
-    "lint:ci:master": "eslint . --ext .js,.jsx,.ts,.tsx --ignore-path .gitignore",
+    "lint:all": "eslint --fix . --ext .js,.jsx,.ts,.tsx --ignore-path .gitignore && yarn tsc",
+    "lint:ci:master": "eslint . --ext .js,.jsx,.ts,.tsx --ignore-path .gitignore && yarn tsc",
     "start": "yarn workspace @holium/realm start",
     "start:onboard": "yarn workspace @holium/realm start:onboard",
     "add:realm": "yarn workspace @holium/realm add -W",


### PR DESCRIPTION
## Description

ESLint doesn't catch everything TSC can, so we can run both: https://stackoverflow.com/questions/60514929/eslint-not-reporting-typescript-compiler-type-checking-errors.  It looks like `--noemit` (disables creating output files) makes it run significantly faster (42s locally).

**Reviewer Checklist**

- [ ] Pipeline passes
- [ ] Docs have been added / updated
- [ ] Tests have been added / updated
- [ ] Has been refactored if necessary
