### PR TITLE
Simpler unmaximze works better

### DIFF
--- a/app/src/renderer/system/desktop/components/AppWindow/AppWindow.tsx
+++ b/app/src/renderer/system/desktop/components/AppWindow/AppWindow.tsx
@@ -12,7 +12,6 @@ import { useToggle } from '@holium/design-system/util';
 
 import {
   denormalizeBounds,
-  isFullWidth,
   normalizeBounds,
 } from 'renderer/lib/window-manager';
 import { useAppState } from 'renderer/stores/app.store';
@@ -418,21 +417,13 @@ const AppWindowPresenter = ({ appWindow }: Props) => {
       const xPos = cursorX.get();
       const win = shellStore.getWindowByAppId(appWindow.appId);
       if (win) {
-        if (isFullWidth(win.prevBounds.width, shellStore.desktopDimensions)) {
-          const relativeX = xPos / dmbPrev.width;
-          controls.start({
-            x: xPos - relativeX * dmb.width,
-            width: dmb.width,
-            height: dmb.height,
-            transition: { duration: 0.2 },
-          });
-        } else {
-          controls.start({
-            width: dmb.width,
-            height: dmb.height,
-            transition: { duration: 0.2 },
-          });
-        }
+        const relativeX = xPos / dmbPrev.width;
+        controls.start({
+          x: xPos - relativeX * dmb.width,
+          width: dmb.width,
+          height: dmb.height,
+          transition: { duration: 0.2 },
+        });
       }
     }
   };


### PR DESCRIPTION
## Description

dragging the window from the half-screen position (unmaximize) was buggy, now it stays on top of the cursor better.

**Reviewer Checklist**

- [ ] Pipeline passes
- [ ] Docs have been added / updated
- [ ] Tests have been added / updated
- [ ] Has been refactored if necessary
