### PR TITLE
Fix appgrid clicking

### DIFF
--- a/app/src/renderer/system/desktop/components/Home/Ship/AppGrid.tsx
+++ b/app/src/renderer/system/desktop/components/Home/Ship/AppGrid.tsx
@@ -44,10 +44,14 @@ const AppGridPresenter = ({ maxWidth }: AppGridProps) => {
       canClick.setToggle(!isDragging);
       if (!isDragging) disableScroll.off();
     });
-
     window.electron.app.onMouseUp(() => {
       canClick.setToggle(true);
     });
+
+    return () => {
+      window.electron.app.removeOnMouseMove();
+      window.electron.app.removeOnMouseUp();
+    };
   }, []);
 
   if (!currentSpace) return null;


### PR DESCRIPTION
Ticket: RE-255

## Description

We were toggling `canClick` only when the mouse moved, so if you dragged at all then tried to click without moving again, it was wrongly blocked: watching `onMouseUp` events fixed the issue.  If you catch any other failed clicks after this, please let me know

**Reviewer Checklist**

- [ ] Pipeline passes
- [ ] Docs have been added / updated
- [ ] Tests have been added / updated
- [ ] Has been refactored if necessary
