### PR TITLE
fix RE-280 by not entering normal fullscreen when we do simplefullscreen

### DIFF
--- a/app/src/main/helpers/fullscreen.ts
+++ b/app/src/main/helpers/fullscreen.ts
@@ -52,8 +52,8 @@ const getFullScreenBounds = () => {
 export const fullScreenWindow = (window: BrowserWindow) => {
   const fullScreenBounds = getFullScreenBounds();
   window.setBounds(fullScreenBounds);
-  window.setFullScreen(true);
   if (isArm64Mac) window.setSimpleFullScreen(true);
+  else window.setFullScreen(true);
   window.webContents.send('set-fullscreen', true);
   window.webContents.send('use-custom-titlebar', isArm64Mac);
 };

--- a/desks/realm/lib/realm-chat.hoon
+++ b/desks/realm/lib/realm-chat.hoon
@@ -393,7 +393,7 @@
   [cards state]
 ::
 ++  delete-message
-::  :realm-chat &action [%delete-message /realm-chat/path-id ~2023.2.3..16.23.37..72f6 ~zod]
+::  :realm-chat &chat-action [%delete-message /realm-chat/path-id ~2023.2.3..16.23.37..72f6 ~zod]
   |=  [act=[=path =msg-id:db] state=state-0 =bowl:gall]
   ^-  (quip card state-0)
   ?>  =(src.bowl our.bowl)


### PR DESCRIPTION
Ticket: RE-280

## Cant exit fullscreen video on desktop from chat

**Reviewer Checklist**

- [ ] Pipeline passes
- [ ] Docs have been added / updated
- [ ] Tests have been added / updated
- [ ] Has been refactored if necessary
