### PR TITLE
Auto-assign author to PR

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -13,4 +13,7 @@ jobs:
     steps:
       - name: Auto Author Assign
         uses: toshimaru/auto-author-assign@v1.6.2
+        with:
+          repo-token: ${{ secrets.GH_TOKEN }}
+
 


### PR DESCRIPTION
Because it makes it easier to at-a-glance see what everyone's working on:

![CleanShot 2023-07-07 at 11 55 06@2x](https://github.com/holium/realm/assets/29574724/e26fe7be-7a8f-443c-8f93-3384bea93ebc)
