### PR TITLE
fix RE-252 by removing 'Edit' menu option when message is pending

### DIFF
--- a/app/src/renderer/apps/Courier/components/ChatMessage.tsx
+++ b/app/src/renderer/apps/Courier/components/ChatMessage.tsx
@@ -311,7 +311,8 @@ export const ChatMessagePresenter = ({
         );
       },
     });
-    if (isOur) {
+    if (isOur && !message.pending) {
+      // don't allow people to edit pending messages
       menu.push({
         id: `${messageRowId}-edit-message`,
         icon: 'Edit',


### PR DESCRIPTION
Ticket: RE-252

## Trying to edit a message before it was actually delivered and chat crashed

**Reviewer Checklist**

- [ ] Pipeline passes
- [ ] Docs have been added / updated
- [ ] Tests have been added / updated
- [ ] Has been refactored if necessary
