### PR TITLE
Rename Lexicon & Trove to %os-trove & %os-lexicon

### DIFF
--- a/desks/realm/app/bazaar.hoon
+++ b/desks/realm/app/bazaar.hoon
@@ -1054,15 +1054,15 @@
         =.  color.native-app            '#EEDFC9'
         =.  icon.native-app             'AppIconLexicon'
         =.  config.native-app           [size=[3 7] titlebar-border=%.n show-titlebar=%.y]
-      =.  catalog.init                  (~(put by catalog.init) %lexicon [%native native-app])
-      =.  grid-index.init               (set-grid-index:helpers:bazaar:core %lexicon grid-index.init)
+      =.  catalog.init                  (~(put by catalog.init) %os-lexicon [%native native-app])
+      =.  grid-index.init               (set-grid-index:helpers:bazaar:core %os-lexicon grid-index.init)
       =|  =native-app:store
         =.  title.native-app            'Trove'
         =.  color.native-app            '#DCDCDC'
         =.  icon.native-app             'AppIconTrove'
         =.  config.native-app           [size=[7 8] titlebar-border=%.n show-titlebar=%.y]
-      =.  catalog.init                  (~(put by catalog.init) %trove [%native native-app])
-      =.  grid-index.init               (set-grid-index:helpers:bazaar:core %trove grid-index.init)
+      =.  catalog.init                  (~(put by catalog.init) %os-trove [%native native-app])
+      =.  grid-index.init               (set-grid-index:helpers:bazaar:core %os-trove grid-index.init)
       init
     ::
     ++  get-stall-apps


### PR DESCRIPTION
Because %lexicon & %trove seem to be conflicting with the old versions.