### PR TITLE
remove spaces check in os-trove on-init

### DIFF
--- a/desks/realm/app/os-trove.hoon
+++ b/desks/realm/app/os-trove.hoon
@@ -26,7 +26,6 @@
 ::
 ++  on-init
   ^-  (quip card _this)
-  ?.  has-spaces:hc  ~|("ERROR: Must have %spaces installed." !!)
   :_  this
   [%pass /spaces %agent [our.bowl %spaces] %watch /updates]~
 ::


### PR DESCRIPTION
## Description
fixes https://github.com/holium/realm/pull/1905#issuecomment-1633903496

No guarantee of order in which agents are started on a fresh desk it seems. %os-trove should assume %spaces exists in order to avoid an on-init crash on a fresh realm where all agents are being initialized that stops it from following %spaces updates. In tests this works, probably because the effect of the follow card is processed after all agents on the desk are started.
