### PR TITLE
Don't remove onMouseDown/onMouseUp in appgrid (disables scrolling)

### DIFF
--- a/app/src/renderer/system/desktop/components/Home/Ship/AppGrid.tsx
+++ b/app/src/renderer/system/desktop/components/Home/Ship/AppGrid.tsx
@@ -46,11 +46,6 @@ const AppGridPresenter = ({ maxWidth }: AppGridProps) => {
     window.electron.app.onMouseUp(() => {
       canClick.setToggle(true);
     });
-
-    return () => {
-      window.electron.app.removeOnMouseMove();
-      window.electron.app.removeOnMouseUp();
-    };
   }, []);
 
   if (!currentSpace) return null;


### PR DESCRIPTION
@ajlamarc I don't see a strong reason to keep this except for a tiny performance win, but you might easily be able to put these removers back in in a way that doesn't disable scrolling afterward.