### PR TITLE
edit-path poke, /table scry

### DIFF
--- a/desks/realm/app/bedrock.hoon
+++ b/desks/realm/app/bedrock.hoon
@@ -72,6 +72,8 @@
         (create-path:db +.act state bowl)
       %create-from-space
         (create-from-space:db +.act state bowl)
+      %edit-path
+        (edit-path:db +.act state bowl)
       %remove-path
         (remove-path:db +.act state bowl)
       %add-peer
@@ -137,15 +139,7 @@
             =/  thepeers    (~(got by peers.state) t.t.path)
             =/  tbls        (tables-by-path:db tables.state t.t.path)
             =/  dels=(list [@da db-del-change])
-              %+  skim
-                ~(tap by del-log.state)
-              |=  [k=@da v=db-del-change]
-              ^-  ?
-              ?-  -.v
-                %del-row   =(path.v t.t.path)
-                %del-peer  =(path.v t.t.path)
-                %del-path  =(path.v t.t.path)
-              ==
+              (dels-by-path:db t.t.path state)
             :~  [%give %fact ~ db-path+!>([thepathrow thepeers tbls schemas.state dels])]
                 [%give %kick [path ~] `src.bowl]
             ==
@@ -182,16 +176,14 @@
         =/  thepeers    (~(got by peers.state) thepath)
         =/  tbls        (tables-by-path:db tables.state thepath)
         =/  dels=(list [@da db-del-change])
-          %+  skim
-            ~(tap by del-log.state)
-          |=  [k=@da v=db-del-change]
-          ^-  ?
-          ?-  -.v
-            %del-row   =(path.v thepath)
-            %del-peer  =(path.v thepath)
-            %del-path  =(path.v thepath)
-          ==
+          (dels-by-path:db thepath state)
         ``db-path+!>([thepathrow thepeers tbls schemas.state dels])
+    ::
+    :: all rows from a given table
+    ::  /db/table/realm-note.json
+      [%x %db %table @ ~]
+        =/  tblname=@tas  i.t.t.t.path
+        ``db-table+!>([tblname (~(got by tables.state) tblname) schemas.state])
     ::
     :: host of a given path
       [%x %host %path *]
@@ -399,7 +391,8 @@
                     state
                   $(index +(index), state (process-db-change:db dbpath change state bowl), result-cards (weld (weld result-cards new-scry) pokes))
               %db-path
-                =/  full=fullpath  !<(fullpath +.+.sign)
+                ~&  %here
+                =/  full=fullpath   !<(fullpath +.+.sign)
                 :: insert pathrow
                 =.  received-at.path-row.full  now.bowl
                 =.  paths.state     (~(put by paths.state) dbpath path-row.full)

--- a/desks/realm/lib/db.hoon
+++ b/desks/realm/lib/db.hoon
@@ -8,6 +8,18 @@
 ::
 :: helpers
 ::
+++  dels-by-path
+  |=  [=path state=state-0]
+  ^-  (list [@da db-del-change])
+  %+  skim
+    ~(tap by del-log.state)
+  |=  [k=@da v=db-del-change]
+  ^-  ?
+  ?-  -.v
+    %del-row   =(path.v path)
+    %del-peer  =(path.v path)
+    %del-path  =(path.v path)
+  ==
 ++  maybe-log
   |=  [hide-debug=? msg=*]
   ?:  =(%.y hide-debug)  ~
@@ -683,6 +695,53 @@
   =/  cards  (weld peer-pokes subscription-facts)
   [cards state]
 ::
+++  edit-path
+::bedrock &db-action [%edit-path /example %host ~ ~ ~ ~[[~zod %host] [~bus %member]]]
+::bedrock &db-action [%edit-path /target %host ~ ~ ~ ~[[~bus %host] [~fed %member]]]
+  |=  [=input-path-row state=state-0 =bowl:gall]
+  ^-  (quip card state-0)
+  :: ensure the path exists
+  =/  path-row    (~(got by paths.state) path.input-path-row)
+  :: ensure this came from our ship
+  ?>  =(our.bowl src.bowl)
+  :: ensure we are the host (ONLY HOST CAN EDIT)
+  ?>  =(our.bowl host.path-row)
+
+  =/  path-sub-wire       (weld /next/(scot %da updated-at.path-row) path.path-row)
+
+  :: only editable fields are:
+  ::  replication
+  ::  default-access
+  ::  table-access
+  ::  constraints
+  =.  replication.path-row              replication.input-path-row
+  =.  default-access.path-row
+    ?~  default-access.input-path-row   default-access.path-row
+    default-access.input-path-row
+  =.  table-access.path-row
+    ?~  table-access.input-path-row     table-access.path-row
+    table-access.input-path-row
+  =.  constraints.path-row
+    ?~  constraints.input-path-row      constraints.path-row
+    constraints.input-path-row
+  =.  updated-at.path-row               now.bowl
+  =.  received-at.path-row              now.bowl
+
+  =.  paths.state     (~(put by paths.state) path.path-row path-row)
+
+  :: emit the change to /next and self-subscriptions (our clients)
+  =/  prs=(list peer)   (~(got by peers.state) path.path-row)
+  =/  tbls              (tables-by-path tables.state path.path-row)
+  =/  dels              (dels-by-path path.path-row state)
+  =/  full=fullpath     [path-row prs tbls schemas.state dels]
+  =/  thechange         db-path+!>(full)
+  =/  cards=(list card)  :~
+    [%give %fact [/db (weld /path path.path-row) path-sub-wire ~] thechange]
+    :: kick subs to force them to re-sub for next update
+    [%give %kick [path-sub-wire ~] ~]
+  ==
+
+  [cards state]
 ++  remove-path
 ::bedrock &db-action [%remove-path /example]
   |=  [=path state=state-0 =bowl:gall]
@@ -1117,6 +1176,7 @@
           [%kick-peer kick-peer]
           [%create-path create-path]
           [%create-from-space de-create-from-space]
+          [%edit-path create-path]
           [%remove-path pa]
           [%create de-create-input-row]
           [%edit (ot ~[[%id de-id] [%input-row de-input-row]])]
@@ -1179,13 +1239,18 @@
         ?~  utbl
           ~
         (de-table-access (need utbl))
+      =/  uprs    (~(get by p.jon) 'peers')
+      =/  prs
+        ?~  uprs
+          ~
+        ((ar (ot ~[[%ship de-ship] [%role (se %tas)]])) (need uprs))
       [
         (pa (~(got by p.jon) 'path'))
         replication
         default-access
         table-access
         ~ :: TODO parse json constraints
-        ((ar (ot ~[[%ship de-ship] [%role (se %tas)]])) (~(got by p.jon) 'peers'))
+        prs
       ]
     ::
     ++  de-table-access

--- a/desks/realm/mar/db/table.hoon
+++ b/desks/realm/mar/db/table.hoon
@@ -1,0 +1,17 @@
+/-  sur=db, common
+/+  lib=db
+::
+|_  tbl=[=type:common pt=pathed-table:sur =schemas:sur]
+++  grad  %noun
+++  grow
+  |%
+  ++  noun  tbl
+  ++  json  (en-table:enjs:lib type.tbl pt.tbl schemas.tbl)
+  --
+::
+++  grab
+  |%
+  ++  noun  [=type:common pt=pathed-table:sur =schemas:sur]
+  --
+--
+

--- a/desks/realm/sur/db.hoon
+++ b/desks/realm/sur/db.hoon
@@ -142,6 +142,7 @@
       :: only from our.bowl
       [%create-path =input-path-row]       :: create a new peers list, sends %get-path to all peers
       [%create-from-space =path space-path=[=ship space=cord] sr=role:membership]  :: create a new peers list based on space members, automatically keeps peers list in sync, sends %get-path to all peers
+      [%edit-path =input-path-row]         :: edit a new peers list
       [%remove-path =path]                    :: remove a peers list and all attached objects in tables, sends %delete-path to all peers
       [%add-peer =path =ship =role]           :: add a peer to an existing peers list, sends %get-path to that peer
       [%kick-peer =path =ship]                :: remove a peer from an existing peers list, sends %delete-path to that peer


### PR DESCRIPTION
necessary for @gdbroman to finish making the Notes app

edit-path and /table examples are in postman

basically, you'll need to send an edit-path poke if you are the %host of the path, in order to set the table-access for "realm-note" type to allow all
