### PR TITLE
RE-376 ensure media block always on own line

### DIFF
--- a/lib/design-system/src/blocks/Bubble/renderFragment.tsx
+++ b/lib/design-system/src/blocks/Bubble/renderFragment.tsx
@@ -1,9 +1,11 @@
 import { Flex, Text } from '../../../general';
 import { Bookmark } from '../../os/Bookmark/Bookmark';
+import { parseMediaType } from '../../util/links';
 import { capitalizeFirstLetter } from '../../util/strings';
 import { convertFragmentsToPreview } from '../ChatInput/fragment-parser';
 import { ImageBlock } from '../ImageBlock/ImageBlock';
 import { LinkBlock } from '../LinkBlock/LinkBlock';
+import { MediaBlock } from '../MediaBlock/MediaBlock';
 import { SpaceBlock } from '../SpaceBlock/SpaceBlock';
 import { BubbleAuthor } from './Bubble.styles';
 import {
@@ -143,7 +145,21 @@ export const renderFragment = (
           </FragmentCodeBlock>
         </CodeWrapper>
       );
-    case 'link':
+    case 'link': {
+      const link = (fragment as FragmentLinkType).link;
+      const { linkType } = parseMediaType(link);
+      if (linkType === 'media') {
+        return (
+          <MediaBlock
+            id={`media-${link}`}
+            mode="embed"
+            variant="content"
+            width={320}
+            url={link}
+            onLoaded={() => {}}
+          />
+        );
+      }
       return (
         <BlockWrapper id={id} key={author + index} className="block-wrapper">
           <LinkBlock
@@ -158,6 +174,7 @@ export const renderFragment = (
           />
         </BlockWrapper>
       );
+    }
     case 'image': {
       const imageFrag = fragment as FragmentImageType;
       return (

--- a/lib/design-system/src/blocks/MediaBlock/MediaBlock.tsx
+++ b/lib/design-system/src/blocks/MediaBlock/MediaBlock.tsx
@@ -76,7 +76,7 @@ export const MediaBlock = ({
     );
   }
   return (
-    <Block {...rest}>
+    <Block {...rest} display="block">
       <MediaWrapper>
         {!isReady && !isError && (
           <Flex


### PR DESCRIPTION
Ticket: RE-376

## Text after a video should always start on a new line

**Reviewer Checklist**

- [ ] Pipeline passes
- [ ] Docs have been added / updated
- [ ] Tests have been added / updated
- [ ] Has been refactored if necessary
