### PR TITLE
fix RE-377 handle og links that don't have an image

### DIFF
--- a/lib/design-system/src/blocks/LinkBlock/LinkBlock.tsx
+++ b/lib/design-system/src/blocks/LinkBlock/LinkBlock.tsx
@@ -11,7 +11,6 @@ import { TweetBlock } from './TweetBlock';
 import {
   extractOGData,
   fetchOGData,
-  LINK_PREVIEW_HEIGHT,
   LinkPreviewType,
   RAW_LINK_HEIGHT,
 } from './util';
@@ -189,9 +188,8 @@ export const LinkBlock = ({
     );
   }
   const ogOrLink = ogHasURL ? openGraph?.ogUrl : link;
-  const blockHeight = ogHasImage ? LINK_PREVIEW_HEIGHT : 100;
   return (
-    <Block id={id} {...rest} height={blockHeight}>
+    <Block id={id} {...rest}>
       {ogHasImage && (
         <LinkImage
           id={id}


### PR DESCRIPTION
Ticket: RE-377

## urbit.org docs links cause infinite loading state for LinkBlock

**Reviewer Checklist**

- [ ] Pipeline passes
- [ ] Docs have been added / updated
- [ ] Tests have been added / updated
- [ ] Has been refactored if necessary
