### PR TITLE
Update maintenance window slots

### DIFF
--- a/shared/src/onboarding/dialogs/util.tsx
+++ b/shared/src/onboarding/dialogs/util.tsx
@@ -86,44 +86,34 @@ type MaintenanceWindow = {
 
 export const maintenanceWindows: MaintenanceWindow[] = [
   {
-    weekDay: 'Monday',
-    startTime: '01:00',
-    endTime: '03:00',
-  },
-  {
-    weekDay: 'Tuesday',
-    startTime: '01:00',
-    endTime: '03:00',
-  },
-  {
     weekDay: 'Wednesday',
-    startTime: '01:00',
-    endTime: '03:00',
+    startTime: '18:00',
+    endTime: '19:00',
   },
   {
     weekDay: 'Thursday',
-    startTime: '01:00',
-    endTime: '03:00',
+    startTime: '00:00',
+    endTime: '01:00',
   },
   {
-    weekDay: 'Friday',
-    startTime: '01:00',
-    endTime: '03:00',
+    weekDay: 'Thursday',
+    startTime: '06:00',
+    endTime: '07:00',
   },
   {
     weekDay: 'Saturday',
-    startTime: '01:00',
-    endTime: '03:00',
+    startTime: '18:00',
+    endTime: '19:00',
   },
   {
     weekDay: 'Sunday',
-    startTime: '01:00',
-    endTime: '03:00',
+    startTime: '00:00',
+    endTime: '01:00',
   },
   {
     weekDay: 'Sunday',
-    startTime: '04:00',
-    endTime: '06:00',
+    startTime: '06:00',
+    endTime: '07:00',
   },
 ];
 


### PR DESCRIPTION
Ticket: RE-420

## Description

Instead of 8 maintenance window slots (0-7) which were all Americas focused but gave needless options for various days of the week, we will be switching to 6 slots (0-5) that accommodate global options.

**Reviewer Checklist**

- [ ] Pipeline passes
- [ ] Docs have been added / updated
- [ ] Tests have been added / updated
- [ ] Has been refactored if necessary
