### PR TITLE
Fix chat back button causing blank view

### DIFF
--- a/app/src/renderer/apps/Courier/app.tsx
+++ b/app/src/renderer/apps/Courier/app.tsx
@@ -12,7 +12,7 @@ import { ChatLog } from './views/ChatLog/ChatLog';
 import { CreateNewChat } from './views/CreateNewChat/CreateNewChat';
 import { Inbox } from './views/Inbox/Inbox';
 
-export const CourierAppPresenter = () => {
+const CourierAppPresenter = () => {
   const { clearInnerNavigation } = useTrayApps();
   const { chatStore } = useShipStore();
 

--- a/app/src/renderer/stores/chat.store.ts
+++ b/app/src/renderer/stores/chat.store.ts
@@ -243,9 +243,6 @@ export const ChatStore = types
         self.inbox.find((chat) => chat.path === path)
       );
       yield ChatIPC.resyncPathIfNeeded(path);
-      if (self.subroute === 'inbox') {
-        self.subroute = 'chat';
-      }
       self.chatLoader.set('loaded');
     }),
     togglePinned: flow(function* (path: string, pinned: boolean) {


### PR DESCRIPTION
Ticket: RE-329

## Description

This was not so much a "crash", rather the cause was:

`subRoute` was redundantly set by `setChat`, and because `selectedChat` was `undefined`, a blank view was shown.

Another lesson in minimizing side effects for methods.

**Reviewer Checklist**

- [ ] Pipeline passes
- [ ] Docs have been added / updated
- [ ] Tests have been added / updated
- [ ] Has been refactored if necessary
