### PR TITLE
Convert add-ship-to-chat call to threaded poke

### DIFF
--- a/app/src/os/services/api/types.ts
+++ b/app/src/os/services/api/types.ts
@@ -93,13 +93,7 @@ export type Message =
   | AckParams
   | (MessageBase & DeleteParams);
 
-export type Json =
-  | boolean
-  | number
-  | string
-  | null
-  | { [key: string]: Json }
-  | Array<Json>;
+export type Json = Record<string, any>;
 
 export interface Thread {
   inputMark: string; // graph-update

--- a/app/src/os/services/ship/chat/chat.service.ts
+++ b/app/src/os/services/ship/chat/chat.service.ts
@@ -6,7 +6,7 @@ import { InvitePermissionType } from 'renderer/stores/models/chat.model';
 
 import AbstractService, { ServiceOptions } from '../../abstract.service';
 import { APIConnection } from '../../api';
-import { Action } from '../../api/types';
+import { Thread } from '../../api/types';
 import { ChatDB, chatDBPreload } from './chat.db';
 import { ChatPathMetadata, ChatPathType, ChatUpdateTypes } from './chat.types';
 
@@ -182,7 +182,7 @@ export class ChatService extends AbstractService<ChatUpdateTypes> {
         )[0] || '';
       metadata.peer = dmPeer;
     }
-    const payload = {
+    const payload: Thread = {
       threadName: 'chat-venter',
       inputMark: 'chat-action',
       outputMark: 'chat-vent',
@@ -195,7 +195,7 @@ export class ChatService extends AbstractService<ChatUpdateTypes> {
           invites: 'anyone',
           'max-expires-at-duration': null,
         },
-      } as unknown as Action,
+      },
     };
     try {
       return await APIConnection.getInstance().conduit.thread(payload);
@@ -262,7 +262,7 @@ export class ChatService extends AbstractService<ChatUpdateTypes> {
   }
 
   async addPeerToChat(path: string, ship: string, host?: string) {
-    const payload = {
+    const payload: Thread = {
       threadName: 'chat-venter',
       inputMark: 'chat-action',
       outputMark: 'chat-vent',
@@ -273,7 +273,7 @@ export class ChatService extends AbstractService<ChatUpdateTypes> {
           path,
           host,
         },
-      } as unknown as Action,
+      },
     };
     try {
       return APIConnection.getInstance().conduit.thread(payload);


### PR DESCRIPTION
Verified that it works through the staging moon, `~nimwyd-ramwyl-dozzod-hostyv`.

The new response structure:

```
{
  'received-at': 1695041544632,
  metadata: {
    image: '',
    title: 'Gus, daniel tester',
    description: '',
    timestamp: '1695041544240',
    creator: '~bidtyl-nomnyl',
    reactions: 'true'
  },
  invites: 'anyone',
  'updated-at': 1695041544632,
  'max-expires-at-duration': 0,
  pins: [],
  'peers-get-backlog': false,
  'created-at': 1695041544632,
  path: '/realm-chat/0v1.tfgf4.0pa4s.ec4qp.7284e.92gc9',
  type: 'group'
}
```