### PR TITLE
fixed rooms isInitiator function 

### DIFF
--- a/app/src/renderer/apps/Rooms/store/RoomsStore.ts
+++ b/app/src/renderer/apps/Rooms/store/RoomsStore.ts
@@ -1,5 +1,5 @@
 // bump
-import { patp2dec } from '@urbit/aura';
+import { patp2bn } from '@urbit/aura';
 import EventsEmitter from 'events';
 import { action, makeObservable, observable } from 'mobx';
 
@@ -42,7 +42,7 @@ export const ridFromTitle = (provider: string, our: string, title: string) => {
 };
 
 const isInitiator = (from: string, to: string) => {
-  return patp2dec(from) > patp2dec(to);
+  return patp2bn(from) > patp2bn(to);
 };
 
 export type OnDataChannel = (


### PR DESCRIPTION
fixed the rooms isInitiator function because patp2dec returned a string rather than a big integer causing mobile to not know the correct initiator. patp2bn now returns as big integer.
