### PR TITLE
Make /provisional-ship-entry non-blocking

### DIFF
--- a/hosting-holium-com/src/pages/payment.tsx
+++ b/hosting-holium-com/src/pages/payment.tsx
@@ -123,15 +123,26 @@ export default function Payment({
         productId: productId.toString(),
         auditTrailCode: 1000,
       });
-      await thirdEarthApi.updatePaymentStatus(token, invoiceId, 'OK');
-      const provisionalResponse = await thirdEarthApi.provisionalShipEntry({
-        token,
-        product: productId.toString(),
-        invoiceId,
-        shipType: 'provisional',
-      });
 
-      if (!provisionalResponse) return false;
+      try {
+        // Critical request, so we quit if it fails.
+        await thirdEarthApi.updatePaymentStatus(token, invoiceId, 'OK');
+      } catch (e) {
+        console.error(e);
+        return false;
+      }
+
+      try {
+        // This server call should be non-blocking since the user has already paid.
+        await thirdEarthApi.provisionalShipEntry({
+          token,
+          product: productId.toString(),
+          invoiceId,
+          shipType: 'provisional',
+        });
+      } catch (e) {
+        console.error(e);
+      }
 
       return goToPage('/upload-id', {
         product_type: 'byop-p',
@@ -149,15 +160,27 @@ export default function Payment({
         auditTrailCode: 1000,
       });
 
-      await thirdEarthApi.updatePaymentStatus(token, invoiceId, 'OK');
-      await thirdEarthApi.updatePlanetStatus(token, serverId, 'sold');
-      await thirdEarthApi.provisionalShipEntry({
-        token,
-        patp: serverId,
-        product: productId.toString(),
-        invoiceId,
-        shipType: 'planet',
-      });
+      try {
+        // Critical request, so we quit if it fails.
+        await thirdEarthApi.updatePaymentStatus(token, invoiceId, 'OK');
+      } catch (e) {
+        console.error(e);
+        return false;
+      }
+
+      try {
+        // These server calls should be non-blocking since the user has already paid.
+        await thirdEarthApi.updatePlanetStatus(token, serverId, 'sold');
+        await thirdEarthApi.provisionalShipEntry({
+          token,
+          patp: serverId,
+          product: productId.toString(),
+          invoiceId,
+          shipType: 'planet',
+        });
+      } catch (e) {
+        console.error(e);
+      }
 
       return goToPage('/booting', {
         product_type,


### PR DESCRIPTION
The endpoint `/provisional-ship-entry` is timing out – that's being investigated. EDIT: it's fixed now.

Meanwhile, the onboarding should proceed from the payment screen without waiting for a response from `/provisional-ship-entry`. If they've paid, server-downtime should not prompt users to pay multiple times, better the flow fails later.

## Example

https://github.com/holium/realm/assets/29574724/cd0242e0-9bea-4bf0-acac-0da98c816c6f

I've re-run through the regular and BYOP flow in TEST.
