### PR TITLE
encodeURI not encodeURIComponent

### DIFF
--- a/app/src/renderer/lib/useStorage.ts
+++ b/app/src/renderer/lib/useStorage.ts
@@ -69,7 +69,7 @@ export const useStorage = ({ accept = '*' } = { accept: '*' }): IuseStorage => {
       const fileName = fileParts.slice(0, -1);
       const fileExtension = fileParts.pop();
 
-      const key = encodeURIComponent(
+      const key = encodeURI(
         `${window.ship}/${moment().unix()}-${fileName}.${fileExtension}`
       );
       const params = {


### PR DESCRIPTION
```
encodeURIComponent("~zod/123123123-sadf asdf.jpg")
'~zod%2F123123123-sadf%20asdf.jpg'
```

the slash is encoded, which is bad

```
encodeURI("~zod/123123123-sadf asdf.jpg")
'~zod/123123123-sadf%20asdf.jpg'
```

this is correct