### PR TITLE
also send peers-get-backlog default

### DIFF
--- a/app/src/os/services/ship/chat/chat.service.ts
+++ b/app/src/os/services/ship/chat/chat.service.ts
@@ -194,6 +194,7 @@ export class ChatService extends AbstractService<ChatUpdateTypes> {
           peers,
           invites: 'anyone',
           'max-expires-at-duration': null,
+          'peers-get-backlog': true,
         },
       },
     };


### PR DESCRIPTION
necessary to match recent changes in desks repo