### PR TITLE
Remove planet_status filter

### DIFF
--- a/hosting-holium-com/src/pages/choose-id.tsx
+++ b/hosting-holium-com/src/pages/choose-id.tsx
@@ -22,9 +22,9 @@ export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   const productId = products[0].id;
 
   const planets = await thirdEarthApi.getPlanets(productId);
-  const identities = Object.values(planets.planets)
-    .filter((planet) => planet.planet_status === 'available')
-    .map((planet) => planet.patp);
+  const identities = Object.values(planets.planets).map(
+    (planet) => planet.patp
+  );
 
   return {
     props: {

--- a/shared/src/onboarding/services/ThirdEarthApi.ts
+++ b/shared/src/onboarding/services/ThirdEarthApi.ts
@@ -43,7 +43,6 @@ type GetPlanetsResponse = {
     [key: number]: {
       id: number;
       patp: string;
-      planet_status: 'available' | 'sold';
       sigil: string;
     };
   };


### PR DESCRIPTION
Returned planets from `/operator/get-planets-to-sell/:operatorId` no longer have a `planet_status` field on them, since all planets are of the supersonic type and can be assumed to be instantly available.
