### PR TITLE
fix the leave option so that it's id is not overwritten

### DIFF
--- a/app/src/renderer/apps/Spaces/SpaceRow.tsx
+++ b/app/src/renderer/apps/Spaces/SpaceRow.tsx
@@ -39,7 +39,7 @@ const SpaceRowPresenter = (props: SpaceRowProps) => {
   const contextMenuOptions = useMemo(() => {
     const menu = [];
     menu.push({
-      id: `space-row-${space.path}-btn-leave`,
+      id: `space-row-${space.path}-btn-copy`,
       label: 'Copy link',
       onClick: (evt: React.MouseEvent<HTMLDivElement>) => {
         evt.stopPropagation();


### PR DESCRIPTION
noticed that right-click on space in the spaces list doesn't have the option to leave any more