### PR TITLE
Replace all third.earth references with holium.network

### DIFF
--- a/app/.holium/configs/webpack.config.renderer.prod.ts
+++ b/app/.holium/configs/webpack.config.renderer.prod.ts
@@ -114,7 +114,7 @@ const configuration: webpack.Configuration = {
         'https://56fbf5e600db48cf8a785931be1ca5e4@o1327359.ingest.sentry.io/4504310987358208',
       AMPLITUDE_API_KEY: 'd6d123a2a660806abcc6b1845c475f2f',
       AMPLITUDE_API_KEY_DEV: '68e00eca14dda372e15a8aadaa0b37ac',
-      API_URL: 'https://backend-server.third.earth',
+      API_URL: 'https://backend-server.holium.network',
       JOIN_API_URL: 'https://join.holium.com',
       API_HEADERS_CLIENT_ID: '5',
       API_HEADERS_VERSION: '2',

--- a/app/src/renderer/apps/Rooms/components/rooms.stories.tsx
+++ b/app/src/renderer/apps/Rooms/components/rooms.stories.tsx
@@ -35,12 +35,6 @@ const contacts: any = {
     avatar:
       'https://lomder-librun.sfo3.digitaloceanspaces.com/Images/~fasnut-famden/1683832836-fasnut-famden%20light%20blue%20green.jpg',
   },
-  '~lopsyp-doztun': {
-    color: '#129131',
-    nickname: 'Gus',
-    avatar:
-      'https://rindux-mocrux.s31.third.earth/~lopsyp-doztun/1683061010-boom.jpeg',
-  },
   '~hostyv': {
     color: '#785218',
     nickname: 'hostyv',

--- a/app/src/renderer/index.ejs
+++ b/app/src/renderer/index.ejs
@@ -5,7 +5,7 @@
   <base href="./" />
   <meta charset="utf-8" />
   <meta http-equiv="Content-Security-Policy" content="
-      connect-src 'self' https://*.stripe.com https://*.sentry.io https://*.amplitude.com ws://localhost:3001 ws://localhost:3030 http://localhost:8545 https://*.plymouth.network https://*.third.earth https://api.unsplash.com https://join.holium.com https://api.holium.live https://socket.holium.live wss://socket.holium.live wss://*.holium.live http://localhost:3000;
+      connect-src 'self' https://*.stripe.com https://*.sentry.io https://*.amplitude.com ws://localhost:3001 ws://localhost:3030 http://localhost:8545 https://*.plymouth.network https://*.holium.network https://api.unsplash.com https://join.holium.com https://api.holium.live https://socket.holium.live wss://socket.holium.live wss://*.holium.live http://localhost:3000;
       frame-src 'self' https://*.stripe.com https://www.youtube.com https://open.spotify.com https://open.spotifycdn.com https://platform.twitter.com https://w.soundcloud.com;
       script-src 'self' https://*.stripe.com https://www.youtube.com https://open.spotify.com https://open.spotifycdn.com https://platform.twitter.com;
       script-src-elem 'self' https://*.stripe.com https://www.youtube.com https://open.spotify.com https://open.spotifycdn.com https://platform.twitter.com https://w.soundcloud.com;


### PR DESCRIPTION
We're replacing all references of third.earth -> holium.network as per @dolled-possum's request.

Both domains are completely interchangeable, so all subdomains continue working just as well.

CC: @drunkplato @lodlev-migdev 